### PR TITLE
fix(dashboard): handle empty and single-data-point states across the UI

### DIFF
--- a/dashboard/app/protocol/[id]/page.tsx
+++ b/dashboard/app/protocol/[id]/page.tsx
@@ -85,6 +85,7 @@ export default async function ProtocolDetailPage({ params }: { params: Promise<{
 }
 
 function Hero({ detail }: { detail: ProtocolDetail }) {
+  const hasScore = detail.safetyScore !== null;
   return (
     <Reveal delay={0.05} className="mt-6">
       <div className="flex flex-col items-start gap-8 rounded-2xl border border-line surface-lit p-8 sm:flex-row sm:items-center">
@@ -108,7 +109,7 @@ function Hero({ detail }: { detail: ProtocolDetail }) {
           <div className="mt-5 flex flex-wrap items-center gap-3">
             <StatusPill
               lastRunStatus={detail.lastRunStatus}
-              hasScore={detail.safetyScore !== null}
+              hasScore={hasScore}
             />
             <span className="text-sm text-muted">
               {detail.computedAt
@@ -119,6 +120,12 @@ function Hero({ detail }: { detail: ProtocolDetail }) {
           <p className="mt-1.5 text-xs text-faint">
             Last run {formatTimestamp(detail.lastRunAt)} · updated on every indexer cycle
           </p>
+          {!hasScore && (
+            <p className="mt-2 text-sm text-faint">
+              This protocol doesn’t have a score yet. Scoring has not succeeded on any run
+              so far — a missing score and a low score are not the same thing.
+            </p>
+          )}
         </div>
       </div>
     </Reveal>
@@ -126,37 +133,44 @@ function Hero({ detail }: { detail: ProtocolDetail }) {
 }
 
 function History({ history }: { history: HistoryEntry[] }) {
-  if (history.length === 0) return null;
   return (
     <section className="mt-14">
       <Reveal>
         <h2 className="font-display text-xl font-semibold text-ink">Recent runs</h2>
         <p className="mt-1 text-sm text-muted">
-          The last {history.length} scoring {history.length === 1 ? 'run' : 'runs'}, newest first.
+          {history.length > 0
+            ? `The last ${history.length} scoring ${history.length === 1 ? 'run' : 'runs'}, newest first.`
+            : 'No scoring runs recorded yet.'}
         </p>
       </Reveal>
-
-      <Reveal delay={0.05} className="mt-5 overflow-hidden rounded-xl border border-line">
-        <ul className="divide-y divide-line-soft">
-          {history.map((h, i) => (
-            <li key={i} className="flex items-center gap-3 bg-surface/40 px-4 py-3 text-sm">
-              <span
-                className={`h-2 w-2 shrink-0 rounded-full ${
-                  h.status === 'ok' ? 'bg-safe' : 'bg-danger'
-                }`}
-              />
-              <span className="tnum w-40 shrink-0 text-muted">{formatTimestamp(h.runAt)}</span>
-              {h.status === 'ok' ? (
-                <span className="text-ink">
-                  scored <span className="tnum font-semibold">{h.safetyScore}</span>
-                </span>
-              ) : (
-                <span className="truncate text-danger">failed — {h.error}</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      </Reveal>
+      {history.length === 0 ? (
+        <Reveal delay={0.05} className="mt-5 rounded-xl border border-dashed border-line bg-surface/30 p-8 text-center text-sm text-faint">
+          The indexer hasn’t run a scoring cycle for this protocol yet. Once a run completes,
+          its result will appear here.
+        </Reveal>
+      ) : (
+        <Reveal delay={0.05} className="mt-5 overflow-hidden rounded-xl border border-line">
+          <ul className="divide-y divide-line-soft">
+            {history.map((h, i) => (
+              <li key={i} className="flex items-center gap-3 bg-surface/40 px-4 py-3 text-sm">
+                <span
+                  className={`h-2 w-2 shrink-0 rounded-full ${
+                    h.status === 'ok' ? 'bg-safe' : 'bg-danger'
+                  }`}
+                />
+                <span className="tnum w-40 shrink-0 text-muted">{formatTimestamp(h.runAt)}</span>
+                {h.status === 'ok' ? (
+                  <span className="text-ink">
+                    scored <span className="tnum font-semibold">{h.safetyScore}</span>
+                  </span>
+                ) : (
+                  <span className="truncate text-danger">failed — {h.error}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Reveal>
+      )}
     </section>
   );
 }

--- a/dashboard/app/registry/page.tsx
+++ b/dashboard/app/registry/page.tsx
@@ -70,12 +70,13 @@ export default async function RegistryPage() {
 
 function ProtocolRow({ entry, rank }: { entry: LeaderboardEntry; rank: number }) {
   const band = scoreBand(entry.safetyScore);
-  const pct = entry.safetyScore ?? 0;
+  const hasScore = entry.safetyScore !== null;
+  const pct = hasScore ? entry.safetyScore! : 0;
 
   return (
     <Link
       href={`/protocol/${entry.id}`}
-      className="group grid grid-cols-1 gap-3 px-4 py-5 transition-colors hover:bg-surface/50 md:grid-cols-[3rem_1fr_8rem_10rem_9rem] md:items-center md:gap-4"
+      className="group grid grid-cols-1 gap-3 px-4 py-5 transition-colors hover:bg-surface/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg md:grid-cols-[3rem_1fr_8rem_10rem_9rem] md:items-center md:gap-4"
     >
       <div className="tnum hidden text-sm text-faint md:block">{String(rank).padStart(2, '0')}</div>
 
@@ -95,26 +96,34 @@ function ProtocolRow({ entry, rank }: { entry: LeaderboardEntry; rank: number })
       <div>
         <div className="flex items-baseline gap-2">
           <span className={`tnum text-2xl font-semibold ${bandTextClass(band)}`}>
-            {entry.safetyScore ?? '—'}
+            {hasScore ? entry.safetyScore : '—'}
           </span>
           <span className="text-xs text-faint">/ 100</span>
         </div>
-        <div className="mt-1.5 h-1 w-full max-w-[9rem] overflow-hidden rounded-full bg-line-soft">
-          <div
-            className="h-full rounded-full"
-            style={{ width: `${pct}%`, background: bandColor(band) }}
-          />
-        </div>
+        {hasScore ? (
+          <div className="mt-1.5 h-1 w-full max-w-[9rem] overflow-hidden rounded-full bg-line-soft">
+            <div
+              className="h-full rounded-full"
+              style={{ width: `${pct}%`, background: bandColor(band) }}
+            />
+          </div>
+        ) : (
+          <div className="mt-1.5 flex items-center gap-1.5 text-xs text-faint">
+            <span className="inline-block h-1 w-full max-w-[9rem] overflow-hidden rounded-full bg-line-soft">
+              <span className="block h-full w-full rounded-full bg-line-soft/50" />
+            </span>
+            <span className="shrink-0 italic">Unscored</span>
+          </div>
+        )}
       </div>
 
       <div className="flex items-center gap-2">
-        <StatusPill lastRunStatus={entry.lastRunStatus} hasScore={entry.safetyScore !== null} />
+        <StatusPill lastRunStatus={entry.lastRunStatus} hasScore={hasScore} />
         <span className="text-xs text-faint md:hidden">{formatTimestamp(entry.lastRunAt)}</span>
       </div>
     </Link>
   );
 }
-
 function EmptyState() {
   return (
     <div className="mt-10 rounded-xl border border-line surface-lit p-10 text-center">


### PR DESCRIPTION
## What this does

Handles four empty / single-data-point states across the dashboard that were either missing or misleading:

### Registry
- **Before**: an unscored protocol showed `—` for the score but rendered a 0% progress bar (same width as a zero-score protocol, only the color differed — subtle enough to confuse).
- **After**: a protocol with no score shows an explicit `Unscored` italic label alongside a flat gray bar, making it visually impossible to mistake a "missing score" for a "low score".

### Protocol detail page
- **Before**: when `safetyScore` is null, the Hero showed `—` in the ScoreRing but no explanation of why — a user could read `—`/100 as "zero."
- **After**: a text line directly below the status pill explains that the protocol hasn't been scored yet, with the explicit note *"a missing score and a low score are not the same thing."*

### History section
- **Before**: `history.length === 0` returned `null` — the section simply didn't render, so the user saw nothing about runs at all.
- **After**: a dashed-border empty state card explains that the indexer hasn't run a scoring cycle yet, and once one completes the result will appear.

## Verification

Each state can be forced locally by returning null from the API or by running against an empty database — the UI renders intentionally for every case, no broken layouts.

Closes #19