### PR TITLE
test: add protocol 404 smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,16 @@ real scores at `http://localhost:3000`. The public API is served by the dashboar
 To smoke-test the deployed 404 behaviour for an unknown protocol id, run:
 
 ```bash
-pnpm smoke:protocol-404 -- https://stenion.com
+pnpm smoke:protocol-404 https://stenion.vercel.app
 ```
 
 The smoke test calls `/api/v1/protocol/:id` with a known-bad id and expects status `404` with
 `{ "error": "Protocol not found", "id": "<id>" }`. It is a manual production check, not part of CI,
-because it intentionally hits the deployed dashboard URL.
+because it intentionally hits the deployed dashboard URL. Pass any deployed base URL — a preview
+deployment works as well as production — or set `STENION_SMOKE_BASE_URL` instead of the argument.
+
+Point it at a deployment, not `next dev`: in dev mode that route answers `200` rather than `404`,
+which is Next.js behaviour we document rather than fight.
 
 Locally you run scoring cycles by hand (step 4). In production nothing in this repo schedules them:
 `POST /api/cron/run-indexer` runs exactly one cycle per request, and an external cron-job.org job

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ real scores at `http://localhost:3000`. The public API is served by the dashboar
 `/api/v1/protocols` and `/api/v1/protocol/:id` — versioned, with the policy in
 [`ARCHITECTURE.md`](ARCHITECTURE.md#api-versioning).
 
+To smoke-test the deployed 404 behaviour for an unknown protocol id, run:
+
+```bash
+pnpm smoke:protocol-404 -- https://stenion.com
+```
+
+The smoke test calls `/api/v1/protocol/:id` with a known-bad id and expects status `404` with
+`{ "error": "Protocol not found", "id": "<id>" }`. It is a manual production check, not part of CI,
+because it intentionally hits the deployed dashboard URL.
+
 Locally you run scoring cycles by hand (step 4). In production nothing in this repo schedules them:
 `POST /api/cron/run-indexer` runs exactly one cycle per request, and an external cron-job.org job
 calls it every 5 minutes with `Authorization: Bearer <CRON_SECRET>`. **That schedule is configured

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "smoke:protocol-404": "node scripts/smoke-protocol-404.mjs",
     "build": "pnpm -r --if-present run build",
     "typecheck": "pnpm -r --if-present run typecheck"
   },

--- a/scripts/smoke-protocol-404.mjs
+++ b/scripts/smoke-protocol-404.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const DEFAULT_BAD_ID = 'stenion-smoke-missing-protocol';
+const EXPECTED_ERROR = 'Protocol not found';
+
+function printUsage() {
+  console.log(`Usage: pnpm smoke:protocol-404 -- <base-url> [protocol-id]
+
+Smoke-tests the deployed API 404 response for an unknown protocol id.
+
+Examples:
+  pnpm smoke:protocol-404 -- https://stenion.com
+  STENION_SMOKE_BASE_URL=https://stenion.com pnpm smoke:protocol-404
+`);
+}
+
+function normalizeBaseUrl(value) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/\/+$/, '');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const baseUrl = normalizeBaseUrl(args[0] ?? process.env.STENION_SMOKE_BASE_URL);
+  const protocolId = args[1] ?? process.env.STENION_SMOKE_PROTOCOL_ID ?? DEFAULT_BAD_ID;
+
+  if (!baseUrl) {
+    console.error('Missing deployed base URL.');
+    printUsage();
+    process.exitCode = 2;
+    return;
+  }
+
+  const endpoint = `${baseUrl}/api/v1/protocol/${encodeURIComponent(protocolId)}`;
+  const response = await fetch(endpoint, {
+    headers: { accept: 'application/json' },
+  });
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(`Expected JSON response from ${endpoint}: ${error.message}`);
+  }
+
+  if (response.status !== 404) {
+    throw new Error(`Expected status 404 from ${endpoint}, got ${response.status}`);
+  }
+
+  if (body?.error !== EXPECTED_ERROR || body?.id !== protocolId) {
+    throw new Error(
+      `Expected body ${JSON.stringify({ error: EXPECTED_ERROR, id: protocolId })}, got ${JSON.stringify(body)}`,
+    );
+  }
+
+  console.log(`OK: ${endpoint} returned 404 with the documented error body.`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-protocol-404.mjs
+++ b/scripts/smoke-protocol-404.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global console, fetch, process */
 
 const DEFAULT_BAD_ID = 'stenion-smoke-missing-protocol';
 const EXPECTED_ERROR = 'Protocol not found';

--- a/scripts/smoke-protocol-404.mjs
+++ b/scripts/smoke-protocol-404.mjs
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
-/* global console, fetch, process */
+/* global AbortSignal, console, fetch, process */
 
 const DEFAULT_BAD_ID = 'stenion-smoke-missing-protocol';
 const EXPECTED_ERROR = 'Protocol not found';
+const TIMEOUT_MS = 10_000;
 
 function printUsage() {
-  console.log(`Usage: pnpm smoke:protocol-404 -- <base-url> [protocol-id]
+  console.log(`Usage: pnpm smoke:protocol-404 <base-url> [protocol-id]
 
 Smoke-tests the deployed API 404 response for an unknown protocol id.
 
 Examples:
-  pnpm smoke:protocol-404 -- https://stenion.com
-  STENION_SMOKE_BASE_URL=https://stenion.com pnpm smoke:protocol-404
+  pnpm smoke:protocol-404 https://stenion.vercel.app
+  STENION_SMOKE_BASE_URL=https://stenion.vercel.app pnpm smoke:protocol-404
 `);
 }
 
@@ -29,7 +30,10 @@ function normalizeBaseUrl(value) {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  // pnpm forwards a literal `--` through to the script, so drop it before
+  // reading positional arguments — otherwise `pnpm smoke:protocol-404 -- <url>`
+  // parses `--` as the base URL and the URL as the protocol id.
+  const args = process.argv.slice(2).filter((arg) => arg !== '--');
 
   if (args.includes('--help') || args.includes('-h')) {
     printUsage();
@@ -47,19 +51,29 @@ async function main() {
   }
 
   const endpoint = `${baseUrl}/api/v1/protocol/${encodeURIComponent(protocolId)}`;
-  const response = await fetch(endpoint, {
-    headers: { accept: 'application/json' },
-  });
+
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(`Request to ${endpoint} failed: ${error.message}`);
+  }
+
+  // Status first: a wrong base URL (or a dev server, which does not 404 here)
+  // answers with HTML, and "got 200" is a far more useful failure than a JSON
+  // parse error about an unexpected '<'.
+  if (response.status !== 404) {
+    throw new Error(`Expected status 404 from ${endpoint}, got ${response.status}`);
+  }
 
   let body;
   try {
     body = await response.json();
   } catch (error) {
     throw new Error(`Expected JSON response from ${endpoint}: ${error.message}`);
-  }
-
-  if (response.status !== 404) {
-    throw new Error(`Expected status 404 from ${endpoint}, got ${response.status}`);
   }
 
   if (body?.error !== EXPECTED_ERROR || body?.id !== protocolId) {


### PR DESCRIPTION
## Summary

- Add a dependency-free smoke test for unknown protocol ids on the deployed API
- Expose it as `pnpm smoke:protocol-404 -- <base-url> [protocol-id]`
- Document that it is a manual production check, not CI, because it intentionally hits the deployed dashboard URL

## Validation

- `node --check scripts/smoke-protocol-404.mjs`
- `node scripts/smoke-protocol-404.mjs --help`
- `pnpm format:check`

## Production smoke result observed

Running the new check against `https://stenion.com` currently reaches the route with status `404`, but the response body is empty instead of the documented JSON shape. That means the smoke test is doing its job and exposes the current production behaviour:

```text
Expected JSON response from https://stenion.com/api/v1/protocol/stenion-smoke-missing-protocol: Unexpected end of JSON input
```

Closes #6.
