### PR TITLE
Drop the DEFAULT 1 on risk_scores.methodology_version and tighten its CHECK

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,12 @@ on-chain inputs, so an old row genuinely cannot be recomputed under new rules. T
 surfaced on the protocol detail and on each history point so the dashboard marks the break
 rather than rendering an unexplained step change. Migrations that add such a column must stay
 writable by the _currently deployed_ indexer: `main` keeps running the old code until it's
-promoted, and both share one Neon database.
+promoted, and both share one Neon database. That is why 0002 shipped the column with a
+`DEFAULT 1` and enforced only the `ok` half of its CHECK; 0004 drops the default and tightens the
+CHECK to the full union, now that the deployed indexer names the column explicitly on both arms.
+The column is therefore required rather than defaulted: a future writer that bumps
+`METHODOLOGY_VERSION` and forgets it fails loudly instead of being silently stamped with the old
+version — a mis-stamp that could never be repaired, since the raw inputs are not stored.
 
 Migrations are raw `.sql` files plus a ~40-line runner (`db/src/migrate.ts`) — no ORM.
 

--- a/db/migrations/0004_methodology_version_required.sql
+++ b/db/migrations/0004_methodology_version_required.sql
@@ -1,0 +1,46 @@
+-- Close the follow-up 0002 left open: drop `methodology_version`'s DEFAULT and
+-- tighten its CHECK to the full ok/failed union.
+--
+-- Why this is a correctness guard, not schema tidiness. 0002's DEFAULT 1 was
+-- correct as well as convenient: a writer that didn't know about the column was
+-- *by definition* scoring under v1, so the silent stamp and the right answer
+-- coincided. Flattening the methodology to v1 (the only version that exists —
+-- see METHODOLOGY.md "Current version") made that coincidence permanent and
+-- inverted it. A future writer that bumps METHODOLOGY_VERSION to 2 and forgets
+-- this column on some new insert path would now be silently stamped 1,
+-- indistinguishable from a correctly-stamped v1 row.
+--
+-- That is exactly the failure this column exists to prevent, and it is
+-- unrepairable: risk_scores stores only outputs — the score and the factor map —
+-- never the raw on-chain inputs, so a mis-stamped row cannot be recomputed to
+-- find out which rulebook produced it. Failing loudly costs one indexer cycle.
+-- Getting it wrong costs the integrity of the history.
+--
+-- SAFE TO APPLY WHILE `main` IS SERVING — the same live-writer hazard 0002 and
+-- 0003 document. The deployed indexer names this column explicitly on both arms
+-- of the union (indexer/src/cycle.ts stamps METHODOLOGY_VERSION on the ok
+-- record; db/src/store.ts's insertRunRecord passes an explicit NULL on the
+-- failed one), so nothing in production relies on the default any more. That is
+-- the precondition 0002 named, and it is met.
+ALTER TABLE risk_scores
+  ALTER COLUMN methodology_version DROP DEFAULT;
+
+-- The failed half was deliberately omitted from 0002: the then-deployed indexer
+-- inserted failed rows without naming the column, so they would have picked up
+-- the default and violated the constraint. With the default gone and the store
+-- writing an explicit NULL, the mirror clause is now true in practice, and
+-- risk_scores_methodology_version_shape becomes the same discriminated union
+-- risk_scores_shape already enforces.
+--
+-- If this ADD CONSTRAINT fails, it is telling the truth: some existing failed
+-- row carries a version stamp. Do NOT paper over it with an UPDATE ... SET NULL
+-- in this file — that would silently rewrite stored history, which is the thing
+-- the version column exists to prevent. Go look at the rows first.
+ALTER TABLE risk_scores
+  DROP CONSTRAINT IF EXISTS risk_scores_methodology_version_shape;
+
+ALTER TABLE risk_scores
+  ADD CONSTRAINT risk_scores_methodology_version_shape CHECK (
+    (status =  'ok' AND methodology_version IS NOT NULL) OR
+    (status <> 'ok' AND methodology_version IS NULL)
+  );

--- a/db/src/store.integration.test.ts
+++ b/db/src/store.integration.test.ts
@@ -196,6 +196,55 @@ describe('Store SQL (integration)', { skip }, () => {
     );
   });
 
+  it('requires a methodology version on ok rows and forbids one on failed rows', async () => {
+    // The other half of the union, added in migration 0004 once the deployed
+    // indexer named the column on both arms. Both directions are asserted
+    // because only one of them is exercised by anything else: every seeded row
+    // in this file is well-formed, so "the constraint accepts a failed row with
+    // no version" proves nothing about whether it would REJECT one carrying a
+    // version. There are zero failed rows in the real database, so this test is
+    // the only thing that ever runs the failed half.
+    const p = id('version-shape');
+    await store.upsertProtocol({
+      id: p,
+      name: 'VersionShape',
+      chain: 'stellar',
+      adapterRef: 'FakeAdapter',
+    });
+
+    // A failed run produced no score, so there is no rulebook to attribute it
+    // to. A version here would be a fabricated attribution.
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO risk_scores (protocol_id, status, error, run_at, methodology_version)
+           VALUES ($1, 'failed', 'boom', now(), 1)`,
+          [p],
+        ),
+      /risk_scores_methodology_version_shape/,
+      'a failed row carrying a version must be rejected',
+    );
+
+    // The direction migration 0004 exists for: with the DEFAULT dropped, a
+    // writer that forgets the column no longer gets silently stamped 1.
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO risk_scores (protocol_id, status, safety_score, factors, computed_at, run_at)
+           VALUES ($1, 'ok', 50, '{}'::jsonb, now(), now())`,
+          [p],
+        ),
+      /risk_scores_methodology_version_shape/,
+      'an ok row with no version must be rejected, not defaulted to 1',
+    );
+
+    // And the well-formed failed row still lands.
+    await insertRun(p, { status: 'failed', error: 'RPC down', runAt: '2026-08-16T11:00:00Z' });
+    const detail = await store.getProtocolDetail(p);
+    assert.equal(detail!.history.length, 1, 'only the well-formed row was written');
+    assert.equal(detail!.history[0].status, 'failed');
+  });
+
   it('carries a per-row methodology version through to the history', async () => {
     // Every row stored today is v1 and there is no second version yet, so live
     // data cannot exercise this. It is seeded instead, for the same reason the


### PR DESCRIPTION
Drop the DEFAULT 1 on risk_scores.methodology_version and tighten its CHECK
Closes #42 