### PR TITLE
Add public coverage API endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,13 +2,16 @@
 
 **Free, public, read-only risk data for Stellar/Soroban DeFi lending protocols.**
 
-Two `GET` endpoints, no authentication, no API key, CORS open to any origin. If you are building a
+Three `GET` endpoints, no authentication, no API key, CORS open to any origin. If you are building a
 wallet, an aggregator, or a dashboard and you want a live safety number for a protocol your users
 are about to interact with, this is the whole surface area.
 
-Everything below was captured from the live production API, not written from the type definitions.
-The example responses are verbatim bodies from a snapshot taken at **2026-08-20T11:05–11:10Z**; the
-numbers move every ~5 minutes, the shapes do not.
+The scored examples below were captured from the live production API, not written from the type
+definitions. Their responses are verbatim bodies from a snapshot taken at
+**2026-08-20T11:05–11:10Z**; the numbers move every ~5 minutes, the shapes do not. The coverage
+example was captured with `curl` from the built route on **2026-08-21T22:15Z**, backed by a fresh
+local database, before that new endpoint had a production URL to call. Recapture it against
+production after promotion.
 
 ---
 
@@ -69,6 +72,9 @@ integrating this API does not create one either.
 ```bash
 # every protocol, ranked
 curl https://stenion.vercel.app/api/v1/protocols
+
+# protocols Stenion assessed and deliberately does not score
+curl https://stenion.vercel.app/api/v1/coverage
 
 # one protocol, with factors and run history
 curl https://stenion.vercel.app/api/v1/protocol/blend
@@ -149,6 +155,72 @@ nobody acts on from a list, and repeating them on every row of every fetch is wa
 the detail response. `deployedOn` is the exception, and for the opposite reason: it is not detail
 you look up after deciding to care, it is part of what the row _is_, and a reader who scans the
 board and leaves has to have seen it.
+
+---
+
+## GET /api/v1/coverage
+
+Protocols and markets Stenion has assessed and deliberately does not score. This is a separate,
+unranked contract: an entry here is a coverage decision, never a failed run or a low score.
+
+**Request**
+
+```bash
+curl https://stenion.vercel.app/api/v1/coverage
+```
+
+**Response** `200 OK`
+
+> The first entry is shown below for readability. The live response returns every current entry in
+> the `coverage` array; this object is verbatim from the live route capture.
+
+```json
+{
+  "coverage": [
+    {
+      "id": "templar",
+      "name": "Templar",
+      "status": "off-chain-state",
+      "logo": null,
+      "links": {
+        "site": null,
+        "docs": null
+      },
+      "contractId": null,
+      "summary": "A NEAR-based protocol whose reserves, balances and positions live on NEAR — the only contract it runs on Soroban is a price oracle.",
+      "reason": [
+        "Templar is a NEAR-based chain-abstraction protocol — it calls its product “Cypher Lending” — and its lending market state lives on NEAR, not on Stellar. Reserves, supply and borrow balances, utilization and collateral positions are all read through NEAR RPC. Stellar’s role is as a wallet and collateral entry point via NEAR’s MPC signing, not as the ledger the lending market runs on.",
+        "The only native-Soroban contract Templar ships is a price oracle. That is one of the five factors Stenion scores; the other four are on another chain. An adapter faithful to what Templar actually is would have to read NEAR, and Stenion’s adapters read trustless Stellar infrastructure and nothing else — that rule is the pitch rather than an implementation detail, so bending it for one protocol would quietly change what every other score means.",
+        "This is a decision about where the data lives, not a judgment about Templar. It could be represented only if Stenion’s model expanded to read another chain, which ROADMAP.md keeps explicitly out of scope."
+      ],
+      "verify": "Follow Templar’s own documentation for where lending state is held, then confirm it against the chain: the Soroban contract it publishes on Stellar exposes an oracle interface (price reads), with no reserve, supply/borrow or position storage. There is no Soroban contract to call get_reserves_list, or any equivalent, against.",
+      "asOf": null
+    }
+  ]
+}
+```
+
+| Field        | Type                 | Notes                                                                                                             |
+| ------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `id`         | string               | Stable, case-sensitive coverage identifier; also the path segment on `/coverage/<id>`.                            |
+| `name`       | string               | Display name.                                                                                                     |
+| `status`     | string               | Machine-readable coverage category. New categories may be added on `v1`; existing values are not renamed on `v1`. |
+| `logo`       | string or null       | Root-relative self-hosted mark, or `null`.                                                                        |
+| `links`      | object               | The protocol's verified `site` and `docs`, each string or `null`.                                                 |
+| `contractId` | string or null       | Full Soroban address only when one was recorded; otherwise `null`.                                                |
+| `summary`    | string               | One-sentence coverage summary.                                                                                    |
+| `reason`     | string[]             | Protocol-specific evidence and reasoning. Quoted measurements remain text, not a numeric score.                   |
+| `verify`     | string               | How an integrator or reader can independently check the decision.                                                 |
+| `asOf`       | `YYYY-MM-DD` or null | Date of a measurement-backed reason. `null` means the decision is structural or no dated check is claimed.        |
+
+There is deliberately **no `safetyScore` key and no JSON numeric value anywhere in this
+response**. Identifiers, dates, and evidence strings can contain digits; none is a value a client
+could mistake for a score. The full evidence ships in the list, so there is no separate
+`GET /api/v1/coverage/:id` endpoint.
+
+The route reads the live leaderboard only to apply the same self-healing dedupe as the registry. A
+protocol that has become scorable cannot appear in both responses. `GET /api/v1/protocols` is
+unchanged byte-for-byte.
 
 ---
 
@@ -490,10 +562,11 @@ the exact masking described above.
 
 Errors, `404`s, and `429`s are `no-store`.
 
-**Polling advice:** the data changes every ~5 minutes, so polling faster than that buys you nothing
-but cache hits. Once a minute is generous. Note that the cache key includes the query string, so
-adding `?t=<random>` to defeat the cache does not get you fresher data — it just guarantees a cache
-miss and pushes you toward the rate limit.
+**Polling advice:** scored data changes every ~5 minutes, so polling those routes faster than that
+buys you nothing but cache hits. Once a minute is generous. Coverage records normally change only
+on deploy and use a one-hour shared-cache TTL, so polling `/coverage` more than hourly is wasteful.
+Note that the cache key includes the query string, so adding `?t=<random>` to defeat the cache does
+not get you fresher data — it just guarantees a cache miss and pushes you toward the rate limit.
 
 ---
 
@@ -606,7 +679,7 @@ a `500` cannot outlive the outage that caused it. Retry with backoff.
 
 ### 405 Method Not Allowed
 
-Both routes are `GET` (plus `HEAD` and `OPTIONS`) only. Any other method returns `405` with an empty
+All three routes are `GET` (plus `HEAD` and `OPTIONS`) only. Any other method returns `405` with an empty
 body.
 
 ### Two rough edges, stated rather than hidden

--- a/API.md
+++ b/API.md
@@ -538,12 +538,19 @@ hide it. The current version is `1`.
 
 ## Caching
 
-Both `/v1` read routes are served through a CDN, with a TTL computed per response from the data in
-the body rather than a fixed constant. The reason is directly relevant to you: a fixed TTL would
-serve a body claiming "the last run succeeded at T" for some seconds after a later run had already
-failed — the cache would be lying in exactly the field that exists to stop us lying about freshness.
+All three `/v1` read routes are served through a CDN. The two scored routes — `/v1/protocols` and
+`/v1/protocol/:id` — use a TTL computed per response from the data in the body rather than a fixed
+constant. The reason is directly relevant to you: a fixed TTL would serve a body claiming "the last
+run succeeded at T" for some seconds after a later run had already failed — the cache would be lying
+in exactly the field that exists to stop us lying about freshness.
 
-**The guarantee: a cached response can hide a newer indexer run by at most 10 seconds.**
+**The guarantee, on those two routes: a cached response can hide a newer indexer run by at most 10
+seconds.**
+
+`GET /api/v1/coverage` is the deliberate exception, and says so rather than quietly differing. Its
+body carries no `lastRunAt` — there is no run behind a coverage decision — and its records change
+only when we deploy, so there is no freshness field for a cache to mask and nothing in the body to
+derive a deadline from. It uses a fixed one-hour shared-cache TTL instead.
 
 What you will actually observe on a `200`:
 
@@ -679,8 +686,8 @@ a `500` cannot outlive the outage that caused it. Retry with backoff.
 
 ### 405 Method Not Allowed
 
-All three routes are `GET` (plus `HEAD` and `OPTIONS`) only. Any other method returns `405` with an empty
-body.
+All three routes are `GET` (plus `HEAD` and `OPTIONS`) only. Any other method returns `405` with an
+empty body.
 
 ### Two rough edges, stated rather than hidden
 
@@ -705,9 +712,9 @@ const detail = await res.json();
 
 ## CORS
 
-Both read routes send `Access-Control-Allow-Origin: *` and answer the preflight, so browser clients
-on any origin can call them directly — no proxy needed. Allowed methods are `GET, OPTIONS`; the only
-allowed request header is `content-type`. Preflights are cached for a day.
+All three read routes send `Access-Control-Allow-Origin: *` and answer the preflight, so browser
+clients on any origin can call them directly — no proxy needed. Allowed methods are `GET, OPTIONS`;
+the only allowed request header is `content-type`. Preflights are cached for a day.
 
 The data is public, read-only, and payment-blind, so `*` is the correct policy here rather than a
 shortcut.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -310,7 +310,8 @@ three things in one Vercel project:
    or a methodology-version change. None of the three is ever drawn through, and a failed run is
    never rendered as a zero.
 
-2. The public API, as Route Handlers: `GET /api/v1/protocols`, `GET /api/v1/protocol/:id`.
+2. The public API, as Route Handlers: `GET /api/v1/protocols`, `GET /api/v1/coverage`,
+   `GET /api/v1/protocol/:id`.
 3. A secret-gated cron-trigger route (`POST /api/cron/run-indexer`) that runs one indexer cycle.
 
 **`@stenion/api`** — a standalone `node:http` REST server. **Not deployed** — see below.
@@ -365,10 +366,12 @@ instead, and `format.test.ts` asserts that mechanically rather than leaving it t
 separate services. Everything runs from the single Next.js app:
 
 - **API** → Next.js Route Handlers inside the dashboard (`app/api/v1/protocols`,
-  `app/api/v1/protocol/[id]`). Same `Store` methods, same JSON as the original standalone API — a
-  transport change, not a rewrite. CORS (`access-control-allow-origin: *`) is set on these two
-  routes only, for future browser/wallet/third-party clients reading public, payment-blind data.
-  `/api/v1/*` is the only public API surface — see "API versioning" below. Both routes are
+  `app/api/v1/coverage`, `app/api/v1/protocol/[id]`). The scored routes use the same `Store` methods
+  and JSON as the original standalone API — a transport change, not a rewrite. The coverage route
+  combines the static coverage module with live leaderboard ids solely for deduplication. CORS
+  (`access-control-allow-origin: *`) is set on these three routes only, for future
+  browser/wallet/third-party clients reading public, payment-blind data. `/api/v1/*` is the only
+  public API surface — see "API versioning" below. All three routes are
   CDN-cached and rate limited — see "Caching and rate limits" below.
 - **Indexer** → triggered by `POST /api/cron/run-indexer`, which calls `runIndexerCycle()` once.
   The route is secret-gated (`Authorization: Bearer <CRON_SECRET>`, compared with
@@ -524,6 +527,13 @@ Shortening _N_ bounds that window; it does not remove it.
 So the TTL is derived from the data in the body (`dashboard/app/api/_cache.ts`): **cache until the
 earliest moment the next indexer run could plausibly land, and no further.**
 
+`GET /api/v1/coverage` is the deliberate exception. Its published records are static and normally
+change only with a deploy, and its body intentionally has no `lastRunAt` from which to derive a
+deadline. It therefore uses a fixed **3,600-second shared-cache TTL**. The route still reads live
+leaderboard ids as a defensive dedupe guard; the one-hour bound limits how long a forgotten
+reciprocal cleanup could leave an entry cached after it becomes scorable. A deployment replaces the
+static records and invalidates the old deployment's cache.
+
 | Constant                   | Value | Why                                                                                                                                                                                                                    |
 | -------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `INDEXER_INTERVAL_SECONDS` | 300   | The cron-job.org cadence; observed median `run_at` spacing is 4m59s.                                                                                                                                                   |
@@ -618,10 +628,11 @@ isn't for the counter itself.
 
 The public API is versioned in the URL. The documented, canonical paths are:
 
-| Endpoint                   | Returns                                             |
-| -------------------------- | --------------------------------------------------- |
-| `GET /api/v1/protocols`    | The leaderboard: every protocol + its latest score. |
-| `GET /api/v1/protocol/:id` | One protocol's detail, factors, and run history.    |
+| Endpoint                   | Returns                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `GET /api/v1/protocols`    | The leaderboard: every protocol + its latest score.    |
+| `GET /api/v1/coverage`     | Assessed protocols and markets Stenion does not score. |
+| `GET /api/v1/protocol/:id` | One protocol's detail, factors, and run history.       |
 
 **The consumer-facing reference is [`API.md`](API.md)**, rendered on the site at `/docs/api`. This
 section owns the _policy_; that document owns the contract as an integrator meets it — request and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,8 @@ One Vercel project = the `dashboard`. A page that renders a repo-root markdown f
 → `METHODOLOGY.md`, `/docs/api` → `API.md`) **must** have an `outputFileTracingIncludes` entry in
 `next.config.mjs` — the file is outside the dashboard dir, and without it the route works in
 `next dev` and fails only in production. The API lives as Next.js Route Handlers
-(`/api/v1/protocols`, `/api/v1/protocol/[id]` — versioned; there are **no** unversioned paths, the
+(`/api/v1/protocols`, `/api/v1/coverage`, `/api/v1/protocol/[id]` — versioned; there are **no**
+unversioned paths, the
 former transitional aliases were removed and now 404, and the versioning policy lives in
 `ARCHITECTURE.md`); the dashboard's own pages read `@stenion/db`'s `Store`
 in-process (no HTTP hop). The indexer is triggered by a secret-gated cron route
@@ -153,7 +154,7 @@ kept but not deployed. Env vars: `DATABASE_URL` (Neon pooled), `STENION_RPC_URL`
 alerts; unset = off), `STENION_RATE_LIMIT_SALT`, and the retry/threshold and rate-limit knobs, which
 all have defaults. Every variable the repo understands is documented in `.env.example`.
 
-The two `/v1` read routes are CDN-cached and rate limited; the cron route is **neither**, and must
+The three `/v1` read routes are CDN-cached and rate limited; the cron route is **neither**, and must
 stay that way — rate limiting an authenticated internal trigger can only block a scheduled run.
 Caching there is meaningless (it's a POST that does work). The rate limiter's counter lives in
 Postgres because serverless has no shared memory, and it **fails open**: a limiter that can 429 the

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ pnpm --filter @stenion/dashboard dev             # http://localhost:3000
 
 The dashboard reads Postgres in-process, so once step 4 has landed at least one row you'll see
 real scores at `http://localhost:3000`. The public API is served by the dashboard at
-`/api/v1/protocols` and `/api/v1/protocol/:id` — versioned, with the policy in
+`/api/v1/protocols`, `/api/v1/coverage`, and `/api/v1/protocol/:id` — versioned, with the policy in
 [`ARCHITECTURE.md`](ARCHITECTURE.md#api-versioning).
 
 ### Using the public API
 
-**The full reference is [`API.md`](API.md)** — both endpoints with live example responses, the
+**The full reference is [`API.md`](API.md)** — all three endpoints with live example responses, the
 `ok`/`failed` history union, the staleness model, error shapes, and the versioning commitment. It's
 also rendered on the site at [/docs/api](https://stenion.vercel.app/docs/api). The summary:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,10 +78,11 @@ commitment — priorities shift as protocols launch and as the project finds fun
   cannot disagree with the history it describes. See [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - **Public API documentation.** [`API.md`](API.md), rendered on the site at `/docs/api`. Until now
   the only way to learn the contract was reading the route handlers on GitHub, which is a barrier
-  for exactly the wallet-integrator audience the API exists for. Covers both endpoints with live
+  for exactly the wallet-integrator audience the API exists for. Covers every endpoint with live
   captured examples, the versioning commitment (additive stays on `v1`, breaking gets a `v2`), the
   `ok`/`failed` history union, the staleness model, rate limits, and error shapes. Every example is
-  a verbatim capture from production rather than written from the types.
+  a verbatim `curl` capture rather than written from the types; a newly-added route is recaptured
+  against production after promotion.
 - **Coverage decisions are published, not just recorded.** The registry now has a second section —
   **"Assessed, and not scored"** — listing what we investigated and declined, with a
   protocol-specific reason and a "verify it yourself" path for each. Until now the only record of
@@ -102,8 +103,10 @@ commitment — priorities shift as protocols launch and as the project finds fun
   `protocols` table. A row there with no history already renders as "never run — a gap in our
   coverage", which is our-pipeline-hasn't-got-there-yet; putting a deliberate decision in the same
   place collides the two states the section exists to separate. It would also inject unscored ids
-  into `GET /api/v1/protocols`, which consumers parse as the ranked leaderboard. Publishing this on
-  the API is a separate additive endpoint — see "Planned".
+  into `GET /api/v1/protocols`, which consumers parse as the ranked leaderboard. The same records
+  now ship from the separate additive `GET /api/v1/coverage` endpoint, with the live leaderboard
+  used only to prevent an entry appearing as both scored and unscored. The API carries the full
+  reason, verification path and measurement date, but no `safetyScore` key or JSON numeric value.
 
   Two things it is **not**: it is unrelated to the not-scorable _run outcome_ below (that is a
   registered market draining below the floor, and needs a breaking third `RunRecord` status), and
@@ -331,17 +334,6 @@ Roughly in priority order, but not committed to dates:
   nothing watches. Naming what the alerting does _not_ cover matters as much as what it does; closing
   it means a second, differently-shaped signal (the cycle could not run at all, as distinct from a
   protocol that could not be scored), which is a separate feature rather than a wider threshold.
-- **`GET /api/v1/coverage` — publishing the unscored list on the API.** The "Assessed, and not
-  scored" section is dashboard-only today. Putting those entries on the API is genuinely useful to
-  an integrator deciding what to show a user searching a protocol name, and it is **additive**, so
-  it stays on `v1`.
-
-  It must be its **own endpoint**, never folded into `GET /api/v1/protocols`. Consumers parse that
-  response as the ranked leaderboard; an entry there with `safetyScore: null` would be rendered by a
-  wallet as a protocol we failed to score rather than one we decided not to, which is precisely the
-  collision the dashboard section is built to avoid. Deferred rather than half-shipped: the shape
-  needs deciding once, since a public endpoint's contract is expensive to change.
-
 - **Scam / fake-asset warning API.** A real-time, queryable warning layer for wallets, built on top
   of [StellarExpert](https://stellar.expert)'s existing scam directory. A secondary feature, not the
   core pitch — but a natural fit for the "read the chain, warn users" mission.

--- a/dashboard/app/api/_http.ts
+++ b/dashboard/app/api/_http.ts
@@ -6,13 +6,13 @@
 // module deliberately imports nothing: it is the part of the response contract
 // that is pure, and therefore the part worth pinning.
 
-// CORS for the PUBLIC data routes only. Stenion's /v1/protocols + /v1/protocol/:id serve
-// public, read-only, payment-blind data — any origin may read them (a wallet, a
-// third-party dashboard, anyone), so `*` is the correct, simplest policy, carried
-// over verbatim from the standalone @stenion/api. NOTE: the Stenion dashboard's
-// own pages do NOT rely on this — they read the Store in-process (see app/lib/api.ts),
-// never cross-origin. CORS here is purely for external browser clients. The cron
-// route deliberately gets NO CORS (it's secret-gated, not public).
+// CORS for the PUBLIC data routes only. Stenion's /v1/protocols, /v1/coverage and
+// /v1/protocol/:id serve public, read-only, payment-blind data — any origin may read
+// them (a wallet, a third-party dashboard, anyone), so `*` is the correct, simplest
+// policy, carried over verbatim from the standalone @stenion/api. NOTE: the Stenion
+// dashboard's own pages do NOT rely on this — they read the Store in-process (see
+// app/lib/api.ts), never cross-origin. CORS here is purely for external browser
+// clients. The cron route deliberately gets NO CORS (it's secret-gated, not public).
 export const CORS_HEADERS: Record<string, string> = {
   'access-control-allow-origin': '*',
   'access-control-allow-methods': 'GET, OPTIONS',

--- a/dashboard/app/api/v1/coverage/route.ts
+++ b/dashboard/app/api/v1/coverage/route.ts
@@ -1,0 +1,52 @@
+// GET /api/v1/coverage — protocols Stenion has assessed and deliberately does
+// not score. This remains separate from the ranked /api/v1/protocols contract:
+// a coverage decision is not a failed or low score.
+
+import { coverageForApi } from '../../../lib/coverage';
+import {
+  CORS_HEADERS,
+  NO_STORE,
+  PREFLIGHT_MAX_AGE_SECONDS,
+  enforceRateLimit,
+  getStore,
+  jsonResponse,
+  publicCacheControl,
+} from '../../_shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Coverage records are static and normally change only with a deploy. The live
+ * leaderboard lookup is a defensive dedupe guard, not their source of truth.
+ * One hour substantially reduces repeated database reads while bounding how
+ * long a forgotten reciprocal cleanup could leave a now-scored entry cached.
+ */
+const COVERAGE_CACHE_TTL_SECONDS = 3_600;
+
+export async function GET(req: Request): Promise<Response> {
+  const limited = await enforceRateLimit(req);
+  if (limited) return limited;
+
+  try {
+    const protocols = await getStore().listProtocolsWithLatestScore();
+    const coverage = coverageForApi(protocols.map((protocol) => protocol.id));
+    return jsonResponse({ coverage }, 200, {
+      'cache-control': publicCacheControl(COVERAGE_CACHE_TTL_SECONDS),
+    });
+  } catch (err) {
+    console.error('GET /api/v1/coverage failed:', err);
+    return jsonResponse({ error: 'Internal server error' }, 500, { 'cache-control': NO_STORE });
+  }
+}
+
+export function OPTIONS(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...CORS_HEADERS,
+      'access-control-max-age': String(PREFLIGHT_MAX_AGE_SECONDS),
+      'cache-control': publicCacheControl(PREFLIGHT_MAX_AGE_SECONDS),
+    },
+  });
+}

--- a/dashboard/app/lib/api.ts
+++ b/dashboard/app/lib/api.ts
@@ -3,7 +3,8 @@
 // ARCHITECTURE NOTE — deploy merge (2026-08-12). The public API used to be a
 // separate @stenion/api service that this module fetched over HTTP (STENION_API_URL).
 // For the Vercel deploy the API is merged INTO this Next.js app as Route Handlers
-// (app/api/v1/protocols, app/api/v1/protocol/[id]) so there is one deployable, not two.
+// (app/api/v1/protocols, app/api/v1/coverage, app/api/v1/protocol/[id]) so there is one deployable,
+// not two.
 //
 // Because the dashboard renders on the server, its pages now read the same
 // @stenion/db Store DIRECTLY here — no HTTP hop, no self-fetch. Self-fetching our

--- a/dashboard/app/lib/coverage.test.ts
+++ b/dashboard/app/lib/coverage.test.ts
@@ -6,6 +6,7 @@ import {
   COVERAGE_STATUS_META,
   COVERAGE_STATUS_ORDER,
   coverageById,
+  coverageForApi,
   coverageToPublish,
   groupCoverage,
   type CoverageEntry,
@@ -144,6 +145,47 @@ describe('coverageToPublish', () => {
     const before = COVERAGE.length;
     coverageToPublish(['templar']);
     assert.equal(COVERAGE.length, before);
+  });
+});
+
+describe('coverageForApi', () => {
+  it('reuses the live-board dedupe rule', () => {
+    const published = coverageForApi(['blend', 'kinetic', 'k2-earn']);
+    assert.ok(!published.some((entry) => entry.id === 'k2-earn'));
+    assert.ok(published.some((entry) => entry.id === 'templar'));
+  });
+
+  it('publishes evidence without exposing a score-shaped value', () => {
+    const body: unknown = { coverage: coverageForApi([]) };
+
+    function assertScoreless(value: unknown, path = 'response'): void {
+      assert.notEqual(typeof value, 'number', `${path} contains a JSON number`);
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => assertScoreless(item, `${path}[${index}]`));
+        return;
+      }
+      if (value === null || typeof value !== 'object') return;
+
+      for (const [key, child] of Object.entries(value)) {
+        assert.notEqual(key, 'safetyScore', `${path} exposes a safetyScore key`);
+        assertScoreless(child, `${path}.${key}`);
+      }
+    }
+
+    assertScoreless(body);
+    for (const entry of coverageForApi([])) {
+      assert.ok(entry.reason.length > 0, `${entry.id} lost its published reasoning`);
+      assert.ok(entry.verify.length > 0, `${entry.id} lost its verification path`);
+      assert.ok('asOf' in entry, `${entry.id} lost its measurement date field`);
+    }
+  });
+
+  it('returns detached arrays and link objects for the public contract', () => {
+    const [published] = coverageForApi([]);
+    const source = COVERAGE.find((entry) => entry.id === published.id);
+    assert.ok(source);
+    assert.notEqual(published.reason, source.reason);
+    assert.notEqual(published.links, source.links);
   });
 });
 

--- a/dashboard/app/lib/coverage.ts
+++ b/dashboard/app/lib/coverage.ts
@@ -64,6 +64,14 @@
  * `deployedOn` label (the YieldBlox pool), so it is no longer a reason to be
  * unscored. A `deprecated` member is absent for the same reason — no evidenced
  * case exists today.
+ *
+ * THESE STRINGS ARE A PUBLIC API CONTRACT. GET /api/v1/coverage publishes this
+ * union raw — the value a client reads is the member name written here, not its
+ * COVERAGE_STATUS_META display text — and API.md commits to that in the v1
+ * terms: adding a member is additive and stays on `v1`, so consumers are told to
+ * tolerate a status they don't recognise. RENAMING OR REMOVING ONE IS BREAKING
+ * AND NEEDS A `v2`. That rules out tidying a member name for readability, which
+ * would otherwise look like a free local edit.
  */
 export type CoverageStatus =
   /** Lending state lives on another chain; reading it would break the trustless-Stellar rule. */

--- a/dashboard/app/lib/coverage.ts
+++ b/dashboard/app/lib/coverage.ts
@@ -147,6 +147,28 @@ export interface CoverageEntry {
 }
 
 /**
+ * The deliberately-versioned public shape for GET /api/v1/coverage.
+ *
+ * Keep this explicit even while it matches CoverageEntry: adding an internal
+ * field to the dashboard model must not silently add it to a public API. All
+ * measured values stay inside explanatory strings and `asOf`; this contract
+ * contains no JSON number and no score-shaped field.
+ */
+export type ApiCoverageEntry = Pick<
+  CoverageEntry,
+  | 'id'
+  | 'name'
+  | 'status'
+  | 'logo'
+  | 'links'
+  | 'contractId'
+  | 'summary'
+  | 'reason'
+  | 'verify'
+  | 'asOf'
+>;
+
+/**
  * Heading and framing per status. `chip` is what stands where a scored row has
  * its number, so it must read as a coverage statement in isolation — never as a
  * grade, and never with a numeral in it.
@@ -300,6 +322,29 @@ export const COVERAGE: readonly CoverageEntry[] = [
 export function coverageToPublish(scoredIds: Iterable<string>): CoverageEntry[] {
   const scored = new Set(scoredIds);
   return COVERAGE.filter((entry) => !scored.has(entry.id));
+}
+
+/**
+ * Public API projection of the entries that are not on the live leaderboard.
+ *
+ * This is intentionally a projection rather than returning CoverageEntry
+ * directly. The endpoint is a public v1 contract, so its fields change only by
+ * an explicit edit here. Arrays and nested objects are copied so consumers of
+ * this helper cannot mutate the static source records.
+ */
+export function coverageForApi(scoredIds: Iterable<string>): ApiCoverageEntry[] {
+  return coverageToPublish(scoredIds).map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    status: entry.status,
+    logo: entry.logo,
+    links: { ...entry.links },
+    contractId: entry.contractId,
+    summary: entry.summary,
+    reason: [...entry.reason],
+    verify: entry.verify,
+    asOf: entry.asOf,
+  }));
 }
 
 /**


### PR DESCRIPTION
Closes #61

## Summary

- add `GET /api/v1/coverage`
- publish assessed-but-not-scored protocols with reasoning and verification paths
- prevent entries from appearing in both coverage and the live leaderboard
- add CORS, rate limiting, error handling, and a one-hour shared-cache TTL
- document the new public API contract

## Contract decisions

- coverage remains separate from `/api/v1/protocols`
- the response includes `reason`, `verify`, and `asOf`
- there is no separate coverage detail endpoint
- there is no `safetyScore` key or JSON numeric value
- identifiers, dates, and evidence strings may contain digits

## Verification

- `pnpm format:check`
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- built endpoint returned `200 OK` against a fresh migrated PostgreSQL database

The dashboard test suite passed with 116 tests and 0 failures.

Local route verification returned:

```text
HTTP/1.1 200 OK
access-control-allow-methods: GET, OPTIONS
access-control-allow-origin: *
cache-control: public, max-age=0, s-maxage=3600
content-type: application/json; charset=utf-8