### PR TITLE
Implemented  a /v1/health endpoint reporting indexer freshness per pr…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,214 +1,140 @@
-# Stenion indexer configuration.
-#
-# Copy this file to .env (gitignored) and adjust as needed:
+# Stenion configuration. Copy to .env (gitignored) and adjust:
 #   cp .env.example .env
 #
-# The indexer validates every value on startup and refuses to run (listing all
-# problems) if anything is missing or malformed — so misconfiguration surfaces
-# immediately, not as confusing runtime output. Real shell/CI env vars take
-# precedence over this file.
+# Real shell/CI env vars win over this file. The indexer validates everything on
+# startup and refuses to run, listing every problem at once.
 
 # --- Required ---
 
-# Soroban RPC endpoint adapters read pool/reserve/oracle state from.
-# The value below is the public, keyless mainnet RPC — fine for trying it out;
-# swap for your own/self-hosted endpoint for anything sustained (the public one
-# is shared and rate-limited).
+# Soroban RPC. The default is the public keyless mainnet endpoint — shared and
+# rate-limited, so use your own for anything sustained.
 STENION_RPC_URL=https://mainnet.sorobanrpc.com
 
-# Horizon endpoint used for admin-account signer/activity data.
+# Horizon, for admin-account signer/activity data.
 STENION_HORIZON_URL=https://horizon.stellar.org
 
-# Postgres connection string the indexer writes run outcomes to. Use the
-# *pooled* connection string from your Neon project dashboard and paste it
-# exactly as given — Neon's carries ?sslmode=require, and the db package
-# rewrites that to sslmode=verify-full before connecting, so there is nothing
-# to hand-edit here. The db package reads this same variable for migrations.
-# See db/.env.example, and db/src/env.ts for why the mode is pinned.
-# Format: postgresql://USER:PASSWORD@HOST/DBNAME?sslmode=require
+# Neon *pooled* connection string, pasted exactly as the Neon dashboard gives it —
+# the db package rewrites sslmode=require to verify-full itself. Migrations use
+# this same variable. See db/src/env.ts for why the mode is pinned.
 DATABASE_URL=postgresql://user:password@ep-example-pooler.region.aws.neon.tech/stenion?sslmode=require
 
-# Shared secret protecting the dashboard's cron-trigger route
-# (POST /api/cron/run-indexer). The route runs one indexer cycle and is called by
-# an external cron-job.org schedule (every 5 min); the secret stops anyone else
-# from spam-triggering it. Generate a long random value, e.g.:
+# Shared secret for POST /api/cron/run-indexer, sent as `Authorization: Bearer <secret>`.
+# The route refuses to run (500) without it, so it is never open. Generate with:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-# The caller must send it as `Authorization: Bearer <CRON_SECRET>`. The route
-# refuses to run (500) if this is unset, so it's never open. Only needed where the
-# cron route runs (the deployed dashboard, and locally to test that route).
+# Only needed where that route runs: the deployed dashboard, or locally to test it.
 CRON_SECRET=replace-with-a-long-random-string
 
-# Note: the Blend pool contract is not configured here — it's a constant the
-# Blend adapter owns, not environment config. Each adapter targets its own
-# pool(s) in code; override via the adapter constructor if ever needed.
+# Adapters own their contract addresses in code — nothing to configure here.
+
+# --- Deploying to Vercel (one project = the dashboard) ---
 #
-# --- Deploying to Vercel (single project = the dashboard) ---
-# The dashboard now hosts the API routes (/api/v1/protocols, /api/v1/protocol/[id]) AND
-# the cron-trigger route in-process, so ALL of these go in the Vercel project's
-# Environment Variables (Production + Preview):
-#   DATABASE_URL         — Neon *pooled* connection string (the one below)
-#   STENION_RPC_URL      — Soroban RPC (the cron route reads on-chain state)
-#   STENION_HORIZON_URL  — Horizon (admin-key signal)
-#   CRON_SECRET          — the shared secret above (the same value is set on the
-#                          cron-job.org job, as an Authorization: Bearer header)
-# Optionally also STENION_ALERT_WEBHOOK_URL (see "Retry and failure alerting"
-# below) — without it the indexer still retries and still records failed runs,
-# it just never tells anyone. The retry/threshold knobs all have defaults and
-# only need setting to override them.
-# Worth setting too: STENION_RATE_LIMIT_SALT (see "Public API rate limiting"
-# below). The rate limiter works without it; the salt is what makes the stored
-# client hashes actually irreversible.
-# STENION_INTERVAL_MS / STENION_RUN_ONCE are NOT used by the cron route (it always
-# runs exactly one cycle); scheduling is external (cron-job.org), and that schedule
-# is configured in their dashboard — it is not in this repo.
+# Set in Production + Preview: DATABASE_URL, STENION_RPC_URL, STENION_HORIZON_URL,
+# CRON_SECRET (the same value goes on the cron-job.org job's Authorization header).
+# Worth adding: STENION_ALERT_WEBHOOK_URL, STENION_RATE_LIMIT_SALT.
+# STENION_INTERVAL_MS / STENION_RUN_ONCE are ignored by the cron route — it always
+# runs exactly one cycle, and the schedule lives in cron-job.org, not in this repo.
 
-# --- Optional (defaults shown; uncomment to override) ---
+# --- Optional: indexer loop (defaults shown) ---
 
-# Scoring-cycle interval in milliseconds. Default 300000 (5 minutes).
-#STENION_INTERVAL_MS=300000
+# Scoring-cycle interval, ms.
+STENION_INTERVAL_MS=300000
 
-# Run a single cycle then exit instead of looping (true/false). Default false.
-# (The `--once` CLI flag does the same thing and overrides this.)
-#STENION_RUN_ONCE=false
+# Run one cycle then exit. The `--once` CLI flag does the same and overrides this.
+STENION_RUN_ONCE=false
 
-# --- Retry and failure alerting ---
+# --- Optional: retry and failure alerting ---
 #
-# A transient RPC blip used to record a failed run silently. The indexer now
-# retries a failing protocol within a wall-clock budget, and notifies a webhook
-# when one fails several cycles in a row. This makes failures LOUDER AND RARER —
-# it does not change what a failure is: a run that ultimately fails is still
-# recorded as `failed`, so a protocol that is genuinely down still shows as down.
+# Retries make failures rarer and louder, never hidden: a run that ultimately
+# fails is still recorded as `failed`. See ARCHITECTURE.md.
 
-# Total attempts per protocol per cycle, INCLUDING the first. Default 3.
-# Set to 1 to disable retry entirely and restore the previous behaviour.
-#STENION_RETRY_ATTEMPTS=3
+# Attempts per protocol per cycle, including the first. 1 disables retry.
+STENION_RETRY_ATTEMPTS=3
 
-# Delay before the 2nd attempt, in ms; doubles for each attempt after (1s, 2s, …).
-# Default 1000. No jitter — one caller and two protocols is not a thundering herd.
-#STENION_RETRY_BASE_DELAY_MS=1000
+# Delay before the 2nd attempt, ms; doubles for each attempt after.
+STENION_RETRY_BASE_DELAY_MS=1000
 
-# Soft cap on a single attempt, in ms. Default 15000. Measured live fetches run
-# 6–10.5s, so this allows a slow-but-working attempt without letting a hung
-# socket eat the cycle. "Soft" because it abandons the in-flight work rather than
-# cancelling it — true cancellation needs an AbortSignal through the Adapter
-# interface (see ROADMAP.md).
-#STENION_ATTEMPT_TIMEOUT_MS=15000
+# Soft cap on a single attempt, ms. Live fetches measure 6–10.5s. "Soft" because it
+# abandons the in-flight work rather than cancelling it (see ROADMAP.md).
+STENION_ATTEMPT_TIMEOUT_MS=15000
 
-# Wall-clock budget for one cycle's run loop, in ms, split between protocols.
-# Default 42000.
-#
-# THIS IS THE ONE TO BE CAREFUL WITH. The cron route runs under Vercel Hobby's
-# `maxDuration = 60`, which cannot be raised, and a cycle killed mid-flight is
-# worse than one that fails cleanly — it can leave one protocol scored and the
-# other neither scored nor recorded as failed. The budget must leave room on top
-# for cold start, pool connect, the protocol upserts, the streak queries and the
-# alert POST. 42s is the conservative end pending real numbers from the Vercel
-# logs; raise it only against observed cycle durations, never by arithmetic alone.
-#STENION_CYCLE_BUDGET_MS=42000
+# Wall-clock budget for one cycle, ms, split between protocols.
+# LOAD-BEARING: the cron route runs under Vercel Hobby's maxDuration=60, which cannot
+# be raised, and a cycle killed mid-flight is worse than one that fails cleanly — it
+# can leave one protocol scored and another neither scored nor recorded as failed.
+# Must leave room for cold start, pool connect, upserts, streak queries and the alert
+# POST. Raise it only against observed cycle durations, never by arithmetic alone.
+STENION_CYCLE_BUDGET_MS=42000
 
-# Consecutive failed cycles before a protocol raises an alert. Default 4, which
-# at the 5-minute cadence is ~20 minutes down. One blip must not page anyone;
-# false pages are how people learn to ignore alerts.
-#STENION_ALERT_THRESHOLD=4
+# Consecutive failed cycles before a protocol alerts. 4 ≈ 20 min at the 5-min cadence.
+# One blip must not page anyone; false pages are how people learn to ignore alerts.
+STENION_ALERT_THRESHOLD=4
 
-# Webhook the indexer POSTs failure and recovery alerts to. UNSET BY DEFAULT,
-# which disables alerting — retries and failed-run recording carry on regardless.
-#
-# Slack and Discord incoming-webhook URLs both work as-is (the payload carries
-# the message under both `text` and `content`, and each service ignores the
-# other's key). Anything that accepts a JSON POST works; the structured form is
-# in the `alerts` array.
-#
-# An alert names the protocol, how many consecutive cycles it has failed, how
-# long that has been, and the underlying error — a recovery message follows when
-# it scores again, so silence after an alert unambiguously means "still down".
-#
-# This is a SECRET (the URL is the credential). Set it in the Vercel project's
-# environment variables, not here.
-#
-# NOT covered by this: a total database outage. No run row is written, so no
-# streak advances and no alert fires — that surfaces as the cron route returning
-# 500, not as a webhook message. See ARCHITECTURE.md.
-#
-# TO VERIFY IT ACTUALLY WORKS, without waiting ~20 minutes for a real outage:
-#   pnpm smoke:alert-webhook              # reads this variable; sends both alerts
+# Webhook for failure and recovery alerts. Unset = alerting off; retries and
+# failed-run recording carry on regardless. Slack and Discord incoming webhooks both
+# work as-is, as does anything accepting a JSON POST.
+# THIS IS A SECRET (the URL is the credential) — set it in Vercel, not here.
+# Does NOT cover a total database outage: no run row is written, so no streak
+# advances and no alert fires. That surfaces as the cron route returning 500.
+# Verify it without waiting for a real outage:
+#   pnpm smoke:alert-webhook              # sends both alerts
 #   pnpm smoke:alert-webhook -- --dry-run # print the payload, send nothing
-# It drives the real path (seeded streak -> runCycle -> decideAlert -> the real
-# webhookNotifier), names an obviously fake protocol so nobody mistakes it for a
-# real outage, and never touches Postgres. See scripts/smoke-alert-webhook.mjs.
-#STENION_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
+STENION_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
 
-# --- Public API rate limiting ---
+# --- Optional: public API rate limiting ---
 #
-# The two public read routes (/api/v1/protocols, /api/v1/protocol/:id) are rate
-# limited per client. The counter is a row in Postgres (table `api_rate_limits`,
-# migration 0005), NOT in memory: serverless gives each invocation its own
-# process, so an in-memory counter would allow N x the limit across N warm
-# instances while reporting that the limit was enforced.
-#
-# WHAT IS COUNTED: only requests that reach the function, i.e. CDN cache MISSES.
-# A cache hit never runs this code and never touches the database, so it is not
-# counted — the limit protects Neon, and a cache hit costs Neon nothing. See
-# ARCHITECTURE.md "Caching and rate limits" for the full reasoning and for what
-# this does and does not protect against.
-#
-# The cron trigger (POST /api/cron/run-indexer) is deliberately NOT rate limited:
-# it is secret-gated and internal, and limiting it could only block a scheduled
-# run. The dashboard's own pages are unaffected too — they read the Store
-# in-process and never go through these routes.
-#
-# NOTHING HERE IS REQUIRED. Every value has a default, a malformed value falls
-# back to that default rather than throwing, and the limiter fails OPEN if its
-# own query errors (including "table does not exist" before you have run the
-# migration) — a broken guard rail must not become a broken API.
+# Per-client token bucket, counted in Postgres (`api_rate_limits`, migration 0005)
+# because serverless has no shared memory. Only CDN cache MISSES are counted — a
+# cache hit never reaches the function. The cron route is deliberately exempt.
+# Nothing here is required: every value has a default, a malformed one falls back to
+# it, and the limiter fails OPEN if its own query errors.
+# Full reasoning in ARCHITECTURE.md "Caching and rate limits".
 
-# Sustained requests per minute per client. Default 60 (one per second).
-#STENION_RATE_LIMIT_PER_MIN=60
+# Sustained requests per minute per client.
+STENION_RATE_LIMIT_PER_MIN=60
 
-# Burst allowance: requests a client may make back-to-back before the sustained
-# rate binds. Default 60 — a full minute's worth up front, because bursty is what
-# honest clients look like.
-#STENION_RATE_LIMIT_BURST=60
+# Burst allowance before the sustained rate binds.
+STENION_RATE_LIMIT_BURST=60
 
-# Salt for the client-key hash. The limiter stores a SHA-256 prefix of the client
-# IP, never the IP itself, so the table cannot become a log of who reads the
-# public API. Unsalted, that hash is reversible by enumerating the IPv4 space —
-# so SET THIS IN PRODUCTION for the pseudonymity to be real. Any long random
-# value; changing it resets everyone's bucket once, which is harmless.
+# Salt for the client-key hash — an IP is stored as a salted SHA-256 prefix, never
+# raw. SET THIS IN PRODUCTION: unsalted, the hash is reversible by enumerating IPv4.
+# Changing it resets every bucket once, which is harmless.
 #   node -e "console.log(require('crypto').randomBytes(16).toString('hex'))"
-#STENION_RATE_LIMIT_SALT=
+STENION_RATE_LIMIT_SALT=
 
-# Off switch. Only the exact string `true` disables the limiter, so a stray value
-# cannot silently turn protection off. Default false (limiter on).
-#STENION_RATE_LIMIT_DISABLED=false
+# Off switch. Only the exact string `true` disables the limiter.
+STENION_RATE_LIMIT_DISABLED=false
+
+# --- Optional: health endpoint thresholds (/api/v1/health) ---
+#
+# Per-protocol run freshness plus one overall status, for an uptime monitor.
+# Staleness is measured from each protocol's last SUCCESSFUL run — an adapter
+# failing every cycle has a perpetually fresh lastRunAt.
+#   healthy   everything within threshold                             200
+#   degraded  some current, some not — probably one broken adapter    503
+#   down      nothing current anywhere — the cron itself looks dead   503
+# Full reasoning in ARCHITECTURE.md "The health endpoint"; contract in API.md.
+
+# How stale a protocol's last successful run may be, in minutes. 30 = six missed
+# cycles, and sits above STENION_ALERT_THRESHOLD (~20 min) so the webhook fires
+# before the monitor goes red. A malformed value falls back to the default.
+STENION_HEALTH_STALE_MINUTES=30
+
+# Multiples of the above, with nothing succeeding anywhere, before `down` rather
+# than `degraded`. 2 = 60 min. A broad RPC outage hits every adapter at once while
+# our own infrastructure is fine, so blaming the cron takes the longer window.
+STENION_HEALTH_DOWN_MULTIPLIER=2
 
 # --- Post-deploy smoke check (scripts/smoke-protocol-404.mjs) ---
 #
-# ⚠️ These two are NOT read from this file. The smoke script is standalone — it
-# reads `process.env` directly and does no .env loading, unlike the indexer and
-# the dashboard. Uncommenting them here does nothing on its own; export them in
-# your shell, or (simpler) pass them as positional arguments, which take
-# precedence over the environment either way:
-#
-#   pnpm smoke:protocol-404 https://stenion.vercel.app
-#   pnpm smoke:protocol-404 https://stenion.vercel.app some-unknown-id
-#
-# They're listed here only so the full set of variables the repo understands is
-# in one place.
-#
-# The script asserts that GET /api/v1/protocol/:id answers 404 with the
-# documented body ({ error: 'Protocol not found', id }) for an id that doesn't
-# exist. It's a manual check against a DEPLOYED URL, not part of `pnpm test` and
-# not run by CI — it needs a live deployment and network access.
+# NOT read from this file — the script reads process.env directly. Export them, or
+# just pass them as arguments, which take precedence either way:
+#   pnpm smoke:protocol-404 https://stenion.vercel.app [some-unknown-id]
+# Listed here only so every variable the repo understands is in one place.
+# Asserts /api/v1/protocol/:id 404s for an unknown id. Manual, against a DEPLOYED
+# URL — `next dev` answers 200 there, so it is not meaningful locally.
 
-# Base URL of the deployment to check. No default: without this (and without a
-# first positional argument) the script prints usage and exits 2. Trailing
-# slashes are stripped. Point it at a real deployment — a local `next dev`
-# server does not 404 on this route, so the check is not meaningful there.
-#STENION_SMOKE_BASE_URL=https://stenion.vercel.app
+# Base URL to check. No default; without it (and no argument) the script exits 2.
+STENION_SMOKE_BASE_URL=https://stenion.vercel.app
 
-# The protocol id to request. Default: stenion-smoke-missing-protocol.
-# It must be an id that does NOT exist — the whole assertion is that the API
-# 404s for it. Setting this to a real protocol ('blend', 'kinetic') makes the
-# script fail, correctly, with "Expected status 404 ... got 200".
-#STENION_SMOKE_PROTOCOL_ID=stenion-smoke-missing-protocol
+# The id to request. Must NOT exist — a real id makes the check fail, correctly.
+STENION_SMOKE_PROTOCOL_ID=stenion-smoke-missing-protocol

--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,10 @@ CRON_SECRET=replace-with-a-long-random-string
 # --- Optional: indexer loop (defaults shown) ---
 
 # Scoring-cycle interval, ms.
-STENION_INTERVAL_MS=300000
+#STENION_INTERVAL_MS=300000
 
 # Run one cycle then exit. The `--once` CLI flag does the same and overrides this.
-STENION_RUN_ONCE=false
+#STENION_RUN_ONCE=false
 
 # --- Optional: retry and failure alerting ---
 #
@@ -48,14 +48,14 @@ STENION_RUN_ONCE=false
 # fails is still recorded as `failed`. See ARCHITECTURE.md.
 
 # Attempts per protocol per cycle, including the first. 1 disables retry.
-STENION_RETRY_ATTEMPTS=3
+#STENION_RETRY_ATTEMPTS=3
 
 # Delay before the 2nd attempt, ms; doubles for each attempt after.
-STENION_RETRY_BASE_DELAY_MS=1000
+#STENION_RETRY_BASE_DELAY_MS=1000
 
 # Soft cap on a single attempt, ms. Live fetches measure 6–10.5s. "Soft" because it
 # abandons the in-flight work rather than cancelling it (see ROADMAP.md).
-STENION_ATTEMPT_TIMEOUT_MS=15000
+#STENION_ATTEMPT_TIMEOUT_MS=15000
 
 # Wall-clock budget for one cycle, ms, split between protocols.
 # LOAD-BEARING: the cron route runs under Vercel Hobby's maxDuration=60, which cannot
@@ -63,11 +63,11 @@ STENION_ATTEMPT_TIMEOUT_MS=15000
 # can leave one protocol scored and another neither scored nor recorded as failed.
 # Must leave room for cold start, pool connect, upserts, streak queries and the alert
 # POST. Raise it only against observed cycle durations, never by arithmetic alone.
-STENION_CYCLE_BUDGET_MS=42000
+#STENION_CYCLE_BUDGET_MS=42000
 
 # Consecutive failed cycles before a protocol alerts. 4 ≈ 20 min at the 5-min cadence.
 # One blip must not page anyone; false pages are how people learn to ignore alerts.
-STENION_ALERT_THRESHOLD=4
+#STENION_ALERT_THRESHOLD=4
 
 # Webhook for failure and recovery alerts. Unset = alerting off; retries and
 # failed-run recording carry on regardless. Slack and Discord incoming webhooks both
@@ -78,7 +78,7 @@ STENION_ALERT_THRESHOLD=4
 # Verify it without waiting for a real outage:
 #   pnpm smoke:alert-webhook              # sends both alerts
 #   pnpm smoke:alert-webhook -- --dry-run # print the payload, send nothing
-STENION_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
+#STENION_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
 
 # --- Optional: public API rate limiting ---
 #
@@ -90,19 +90,19 @@ STENION_ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
 # Full reasoning in ARCHITECTURE.md "Caching and rate limits".
 
 # Sustained requests per minute per client.
-STENION_RATE_LIMIT_PER_MIN=60
+#STENION_RATE_LIMIT_PER_MIN=60
 
 # Burst allowance before the sustained rate binds.
-STENION_RATE_LIMIT_BURST=60
+#STENION_RATE_LIMIT_BURST=60
 
 # Salt for the client-key hash — an IP is stored as a salted SHA-256 prefix, never
 # raw. SET THIS IN PRODUCTION: unsalted, the hash is reversible by enumerating IPv4.
 # Changing it resets every bucket once, which is harmless.
 #   node -e "console.log(require('crypto').randomBytes(16).toString('hex'))"
-STENION_RATE_LIMIT_SALT=
+#STENION_RATE_LIMIT_SALT=
 
 # Off switch. Only the exact string `true` disables the limiter.
-STENION_RATE_LIMIT_DISABLED=false
+#STENION_RATE_LIMIT_DISABLED=false
 
 # --- Optional: health endpoint thresholds (/api/v1/health) ---
 #
@@ -117,12 +117,12 @@ STENION_RATE_LIMIT_DISABLED=false
 # How stale a protocol's last successful run may be, in minutes. 30 = six missed
 # cycles, and sits above STENION_ALERT_THRESHOLD (~20 min) so the webhook fires
 # before the monitor goes red. A malformed value falls back to the default.
-STENION_HEALTH_STALE_MINUTES=30
+#STENION_HEALTH_STALE_MINUTES=30
 
 # Multiples of the above, with nothing succeeding anywhere, before `down` rather
 # than `degraded`. 2 = 60 min. A broad RPC outage hits every adapter at once while
 # our own infrastructure is fine, so blaming the cron takes the longer window.
-STENION_HEALTH_DOWN_MULTIPLIER=2
+#STENION_HEALTH_DOWN_MULTIPLIER=2
 
 # --- Post-deploy smoke check (scripts/smoke-protocol-404.mjs) ---
 #
@@ -134,7 +134,7 @@ STENION_HEALTH_DOWN_MULTIPLIER=2
 # URL — `next dev` answers 200 there, so it is not meaningful locally.
 
 # Base URL to check. No default; without it (and no argument) the script exits 2.
-STENION_SMOKE_BASE_URL=https://stenion.vercel.app
+#STENION_SMOKE_BASE_URL=https://stenion.vercel.app
 
 # The id to request. Must NOT exist — a real id makes the check fail, correctly.
-STENION_SMOKE_PROTOCOL_ID=stenion-smoke-missing-protocol
+#STENION_SMOKE_PROTOCOL_ID=stenion-smoke-missing-protocol

--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 **Free, public, read-only risk data for Stellar/Soroban DeFi lending protocols.**
 
-Three `GET` endpoints, no authentication, no API key, CORS open to any origin. If you are building a
+Four `GET` endpoints, no authentication, no API key, CORS open to any origin. If you are building a
 wallet, an aggregator, or a dashboard and you want a live safety number for a protocol your users
 are about to interact with, this is the whole surface area.
 
@@ -12,6 +12,12 @@ definitions. Their responses are verbatim bodies from a snapshot taken at
 example was captured with `curl` from the built route on **2026-08-21T22:15Z**, backed by a fresh
 local database, before that new endpoint had a production URL to call. Recapture it against
 production after promotion.
+
+The `/v1/health` examples are mixed, and marked individually at the endpoint. The `healthy` body was
+captured from the route's code path against the live production database on **2026-08-22T18:29Z**,
+before that endpoint had a public URL to `curl` — recapture it over HTTP after promotion. The
+`degraded` body is **constructed, not captured**: `risk_scores` has never held a failed run, so that
+state has never occurred in production and cannot be observed until it does.
 
 ---
 
@@ -78,6 +84,9 @@ curl https://stenion.vercel.app/api/v1/coverage
 
 # one protocol, with factors and run history
 curl https://stenion.vercel.app/api/v1/protocol/blend
+
+# is the data fresh? (answers 503 when it is not)
+curl -i https://stenion.vercel.app/api/v1/health
 ```
 
 ---
@@ -516,6 +525,139 @@ on the protocol.
 
 `safetyScore: null` together with `lastRunStatus: "failed"` means we have **never** had a good score
 for that protocol. Render it as unknown. It is not a zero.
+
+---
+
+## GET /api/v1/health
+
+The machine-readable version of everything the previous section just described. Point an uptime
+monitor at it and you will know when our data stops updating without polling scores and diffing
+timestamps yourself.
+
+**Request**
+
+```bash
+curl -i https://stenion.vercel.app/api/v1/health
+```
+
+**Response** — `200 OK`
+
+This one is a real capture: taken from the route's own code path against the live production
+database on **2026-08-22T18:29Z**, before the endpoint had a public URL to `curl`.
+
+```json
+{
+  "status": "healthy",
+  "thresholdMinutes": 30,
+  "protocols": [
+    {
+      "id": "blend",
+      "lastSuccessfulRunAt": "2026-08-22T18:25:03.624Z",
+      "lastRunAt": "2026-08-22T18:25:03.624Z",
+      "lastRunStatus": "ok",
+      "staleMinutes": 5
+    },
+    {
+      "id": "kinetic",
+      "lastSuccessfulRunAt": "2026-08-22T18:25:10.953Z",
+      "lastRunAt": "2026-08-22T18:25:10.953Z",
+      "lastRunStatus": "ok",
+      "staleMinutes": 4
+    },
+    {
+      "id": "yieldblox",
+      "lastSuccessfulRunAt": "2026-08-22T18:25:06.632Z",
+      "lastRunAt": "2026-08-22T18:25:06.632Z",
+      "lastRunStatus": "ok",
+      "staleMinutes": 4
+    }
+  ]
+}
+```
+
+**Response** — `503 Service Unavailable`
+
+> **This second body is NOT a capture.** `risk_scores` has never held a failed run in production, so
+> `degraded` has never occurred and cannot be captured. It is constructed from the route's tests.
+> The shape is exact; the values are illustrative.
+
+```json
+{
+  "status": "degraded",
+  "thresholdMinutes": 30,
+  "protocols": [
+    {
+      "id": "blend",
+      "lastSuccessfulRunAt": "2026-08-22T12:41:00.000Z",
+      "lastRunAt": "2026-08-22T12:41:00.000Z",
+      "lastRunStatus": "ok",
+      "staleMinutes": 9
+    },
+    {
+      "id": "kinetic",
+      "lastSuccessfulRunAt": "2026-08-22T09:10:00.000Z",
+      "lastRunAt": "2026-08-22T12:49:00.000Z",
+      "lastRunStatus": "failed",
+      "staleMinutes": 220
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field                             | Type                                | Meaning                                                                                                                                     |
+| --------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`                          | `"healthy" \| "degraded" \| "down"` | The overall verdict. See below.                                                                                                             |
+| `thresholdMinutes`                | number                              | The staleness threshold this response was judged against. Echoed so you never have to guess what produced the verdict.                      |
+| `protocols[].id`                  | string                              | The protocol slug, same id as everywhere else in this API.                                                                                  |
+| `protocols[].lastSuccessfulRunAt` | ISO 8601 \| `null`                  | The newest run that **succeeded**. `null` = never scored successfully.                                                                      |
+| `protocols[].lastRunAt`           | ISO 8601 \| `null`                  | The newest run of **any** outcome. `null` = never ran.                                                                                      |
+| `protocols[].lastRunStatus`       | `"ok" \| "failed" \| null`          | Outcome of that newest run. Same vocabulary as `/v1/protocols` — `ok`/`failed`, not `success`/`failure`.                                    |
+| `protocols[].staleMinutes`        | number \| `null`                    | Whole minutes since `lastSuccessfulRunAt`, computed at request time. `null` when there is no successful run to measure from — **not zero**. |
+
+Protocols are ordered by `id`. That is deliberate and carries no ranking: entries here are only ever
+current or not, and alphabetical is the one ordering that asserts nothing about which protocol is
+doing better.
+
+### The status, and the HTTP code
+
+| `status`   | Meaning                                                                | HTTP  |
+| ---------- | ---------------------------------------------------------------------- | ----- |
+| `healthy`  | Every protocol scored successfully within `thresholdMinutes`.          | `200` |
+| `degraded` | Some protocols are current, some are not. Probably one broken adapter. | `503` |
+| `down`     | Nothing is current anywhere. Our indexer itself looks dead.            | `503` |
+
+**Both non-healthy states answer `503`**, so a monitor that only reads the status line works with no
+body parsing at all. The distinction between them is for the human who opens it afterwards.
+
+A `500` on this route means something different from a `503`: `503` is us successfully reporting
+that the pipeline is behind, `500` is us being unable to find out. If you alert on this endpoint,
+they are both worth catching, but only the `503` tells you the scores are aging.
+
+### How to read it
+
+- **Staleness is measured from `lastSuccessfulRunAt`, never `lastRunAt`.** An adapter failing every
+  five minutes has a perpetually fresh `lastRunAt`; measuring from it would report the exact failure
+  this endpoint exists to catch as perfectly healthy.
+- **The two timestamps together tell you where the problem is.** A fresh `lastRunAt` beside a stale
+  `lastSuccessfulRunAt` is one adapter failing while our pipeline runs fine. Both stale together
+  means our indexer is not running at all. The `kinetic` row above is the first case.
+- **A single fresh failure does not make us unhealthy.** If a protocol's newest run failed but its
+  newest _success_ is minutes old, `status` stays `healthy` — the data you are being served is
+  current, and we would rather not cry wolf over one cycle. Sustained failure crosses the threshold
+  on its own. If you want to react to any failed cycle, read `lastRunStatus` yourself; that is why
+  it is published.
+
+### Caching and limits
+
+**Never cached** — this route sends `Cache-Control: no-store`, unlike the other three. A health
+check that can be stale is a contradiction, and a cached `503` would go on being served after we
+recovered. It is rate limited like everything else, which at 60 requests/minute is far more than a
+monitor probing every 30 seconds will use.
+
+Polling faster than once a minute gains you nothing: we re-score every ~5 minutes, so the answer
+cannot change more often than that.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,7 +311,7 @@ three things in one Vercel project:
    never rendered as a zero.
 
 2. The public API, as Route Handlers: `GET /api/v1/protocols`, `GET /api/v1/coverage`,
-   `GET /api/v1/protocol/:id`.
+   `GET /api/v1/protocol/:id`, `GET /api/v1/health`.
 3. A secret-gated cron-trigger route (`POST /api/cron/run-indexer`) that runs one indexer cycle.
 
 **`@stenion/api`** — a standalone `node:http` REST server. **Not deployed** — see below.
@@ -366,13 +366,14 @@ instead, and `format.test.ts` asserts that mechanically rather than leaving it t
 separate services. Everything runs from the single Next.js app:
 
 - **API** → Next.js Route Handlers inside the dashboard (`app/api/v1/protocols`,
-  `app/api/v1/coverage`, `app/api/v1/protocol/[id]`). The scored routes use the same `Store` methods
-  and JSON as the original standalone API — a transport change, not a rewrite. The coverage route
-  combines the static coverage module with live leaderboard ids solely for deduplication. CORS
-  (`access-control-allow-origin: *`) is set on these three routes only, for future
-  browser/wallet/third-party clients reading public, payment-blind data. `/api/v1/*` is the only
-  public API surface — see "API versioning" below. All three routes are
-  CDN-cached and rate limited — see "Caching and rate limits" below.
+  `app/api/v1/coverage`, `app/api/v1/protocol/[id]`, `app/api/v1/health`). The scored routes use the
+  same `Store` methods and JSON as the original standalone API — a transport change, not a rewrite.
+  The coverage route combines the static coverage module with live leaderboard ids solely for
+  deduplication. The health route reports indexer freshness and nothing else — see "The health
+  endpoint" below. CORS (`access-control-allow-origin: *`) is set on these four routes only, for
+  future browser/wallet/third-party clients reading public, payment-blind data. `/api/v1/*` is the
+  only public API surface — see "API versioning" below. All four are rate limited; three of them are
+  CDN-cached and health deliberately is not — see "Caching and rate limits" below.
 - **Indexer** → triggered by `POST /api/cron/run-indexer`, which calls `runIndexerCycle()` once.
   The route is secret-gated (`Authorization: Bearer <CRON_SECRET>`, compared with
   `crypto.timingSafeEqual`); if `CRON_SECRET` is unset it refuses to run, so it's never open. No
@@ -527,6 +528,21 @@ Shortening _N_ bounds that window; it does not remove it.
 So the TTL is derived from the data in the body (`dashboard/app/api/_cache.ts`): **cache until the
 earliest moment the next indexer run could plausibly land, and no further.**
 
+`GET /api/v1/health` is the other, and it goes the opposite way: **`no-store`, never cached at
+all.** The reasoning above works because the thing a cache could hide changes only when a run lands,
+so expiring before the next run closes the hole. Health does not behave that way — staleness
+advances with the wall clock, so a body built at 29 minutes stale and cached for even 45 seconds is
+still being served, saying `healthy` with a `200`, after the true answer has become `degraded` with
+a `503`. The window is small; the endpoint is the one whose entire purpose is to be believed about
+freshness, and a health check that can be stale is a contradiction rather than a tradeoff. The
+`503`s must not be cached either, for a stronger reason: the CDN cache key is the URL, so a cached
+`503` would go on being served to everyone after the pipeline recovered, turning a resolved incident
+into an ongoing one. What it costs is one database round trip per request, uncushioned. Measured
+from a dev machine on 2026-08-22, warm: **0.4–1.1s for `listRunHealth` against 1.1–1.2s for the
+leaderboard query**, both dominated by network round trip rather than by the query — so the
+uncached route is no more expensive per request than the cached one, and it is bounded above by the
+rate limiter.
+
 `GET /api/v1/coverage` is the deliberate exception. Its published records are static and normally
 change only with a deploy, and its body intentionally has no `lastRunAt` from which to derive a
 deadline. It therefore uses a fixed **3,600-second shared-cache TTL**. The route still reads live
@@ -624,6 +640,111 @@ refused, so a flood costs one write per block window rather than one per request
 ever refuse faster, never allow, which is what makes a per-instance structure sound there when it
 isn't for the counter itself.
 
+### The health endpoint
+
+`GET /api/v1/health` answers one question — **is the indexer still producing data?** — in a form a
+machine can act on.
+
+**Why it exists.** Scoring silently stopping is the worst failure mode this system has, and it is
+worst precisely because nothing goes red. The site keeps serving last-known scores, every page
+renders, no route 500s, and the numbers quietly age. Before this endpoint the only ways to notice
+were to query Neon by hand or to eyeball a timestamp in the UI and compare it against a clock. The
+indexer's failure webhook (see "Retry and failure alerting") covers a different case: it fires when
+an adapter fails repeatedly, and it cannot fire at all if the cron simply stops arriving, because
+nothing runs to notice. This endpoint is the outside-in check that catches that.
+
+**Staleness is measured from the last _successful_ run.** A failed run produced no score. Measuring
+from `lastRunAt` would let an adapter that fails reliably every five minutes report as perfectly
+fresh forever — inverting the endpoint's purpose. So `staleMinutes` is the age of the newest `ok`
+run and nothing else.
+
+`lastRunAt` / `lastRunStatus` are still published per protocol, because read together with the
+above they say **where** the problem is:
+
+| `lastRunAt` | `lastSuccessfulRunAt` | What it means                                            |
+| ----------- | --------------------- | -------------------------------------------------------- |
+| fresh       | fresh                 | Working.                                                 |
+| fresh       | stale                 | The cron is arriving; this adapter is failing. Isolated. |
+| stale       | stale                 | The cron is not arriving. Infrastructure.                |
+| `null`      | `null`                | Registered but never indexed.                            |
+
+**Three states, not a boolean.** "Unhealthy" conflates one adapter failing (a code bug in one file)
+with nothing succeeding anywhere (the pipeline is down). Those have different owners and different
+first moves, and a single flag forces an operator to open the body to find out which — which is what
+having a status is supposed to avoid.
+
+| `status`   | Meaning                                                                     | HTTP  |
+| ---------- | --------------------------------------------------------------------------- | ----- |
+| `healthy`  | Every protocol scored successfully within the threshold.                    | `200` |
+| `degraded` | Some current, some not — or all stale but inside the down window.           | `503` |
+| `down`     | Nothing current anywhere, past the down window. The cron itself looks dead. | `503` |
+
+Both non-healthy states answer **`503`**, so an uptime monitor catches either without parsing the
+body; the distinction between them is for the human who then opens it. `503` rather than `500`
+because nothing errored — the route queried successfully and is telling the truth about a pipeline
+that is behind, which is exactly what `503` means. A genuine `500` on this route means we could not
+find out, and keeping those on separate codes is what lets a monitor tell "the indexer is stopped"
+from "the health check is broken".
+
+**The thresholds**, both configurable, defaults in `dashboard/app/api/_health.ts`:
+
+| Setting                          | Default | Why                                                                                                                                                                 |
+| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STENION_HEALTH_STALE_MINUTES`   | 30      | Six missed cycles at the ~5-minute cadence. Sits above `STENION_ALERT_THRESHOLD` (4 cycles, ~20 min) so the webhook mentions a problem before the monitor goes red. |
+| `STENION_HEALTH_DOWN_MULTIPLIER` | 2       | 60 minutes with not one successful run anywhere before blaming the cron itself.                                                                                     |
+
+30 is sized against what already exists rather than picked round. The indexer's alert threshold is
+4 consecutive cycles, on the stated reasoning that "a score 20 minutes stale is not an emergency —
+false pages are how people learn to ignore alerts". A `503` an uptime monitor consumes is a louder
+signal than that webhook, so it must sit at a higher bar; 30 > 20 gives the intended escalation
+order. The floor is set by the cadence: under ~10 minutes, one slow cycle, a cold start, or a single
+cron-job.org misfire would read as an outage.
+
+The down window exists because "everything is stale at once" is weaker evidence than it sounds.
+Every adapter shares Soroban RPC and Horizon, so a broad upstream outage takes them all out together
+while our own infrastructure is fine — and calling that "the cron is dead" sends an operator to the
+wrong place. With three targets today (one adapter serving several of them), "all of them" is a
+small sample. Doubling the window costs nothing operationally, because `degraded` is already `503`
+and a monitor has already fired; all it buys is the confidence to name which thing broke. The window
+is measured from the **freshest** success across the registry — the most generous reading available,
+so the endpoint can never report worse than the truth.
+
+**A fresh failure alone is not unhealthy.** A protocol whose newest run failed but whose newest
+_success_ is four minutes old reports `healthy`. That is deliberate. The indexer already retries
+(default 3 attempts) before recording a failure at all, but it is still one cycle, and the data it
+protects is current — turning red there pages someone about a blip. Repeated failure is not missed:
+an adapter that keeps failing stops producing successful runs and crosses the threshold on its own.
+Sustained failure and staleness are the same event seen at different times, so staleness alone
+catches it with the transient case filtered out for free. A consumer who does want to act on any
+single failed cycle reads `lastRunStatus`, which is why it is published.
+
+**One query, no fan-out.** `Store.listRunHealth()` reuses the same two `LEFT JOIN LATERAL`
+subqueries the leaderboard uses over the existing `(protocol_id, run_at DESC)` index — the `ok` side
+just selects `run_at` instead of the score. **No schema change was needed**; the row that answers
+this was already one column away. Nothing score-derived is selected: no `safety_score`, no `factors`
+jsonb, so a freshness probe cannot fail because a score was malformed, and no adapter error text is
+republished on an unauthenticated endpoint. A health check that fans out per protocol gets slower in
+proportion to how much there is to report on, and a probe that times out under load is
+indistinguishable from the outage it exists to detect.
+
+**A cold Neon can make this probe time out, and that is left alone deliberately.** Measured on
+2026-08-22, the first query against a Neon instance scaled to zero took ~20s; Vercel's default route
+timeout is 10s, so such a probe returns a platform `504` rather than this route's own `503`. Raising
+`maxDuration` to chase a nicer body is not worth it: Neon only goes cold when nothing has touched it
+for a long while, which on this deployment means the indexer has stopped — precisely the case where
+the verdict is "unhealthy" regardless. A monitor treats `504` and `503` identically, so the answer
+survives; only the body is lost, and buying it back would make every healthy probe wait longer.
+
+An empty registry reports `down`, not `healthy`. Vacuous truth is the wrong answer for a probe:
+"nothing is stale because there is nothing" is a database migrated but never indexed, or one pointed
+at the wrong connection string.
+
+The policy — what stale means, the three states, the HTTP mapping — lives in
+`dashboard/app/api/_health.ts`, a leaf module with **no imports at all**, for the same reason
+`_cache.ts` and `_http.ts` are: every interesting state here is one production has never produced
+(`risk_scores` has never held a `failed` row), so it is asserted in `_health.test.ts` or it is
+asserted nowhere.
+
 ### API versioning
 
 The public API is versioned in the URL. The documented, canonical paths are:
@@ -633,6 +754,7 @@ The public API is versioned in the URL. The documented, canonical paths are:
 | `GET /api/v1/protocols`    | The leaderboard: every protocol + its latest score.    |
 | `GET /api/v1/coverage`     | Assessed protocols and markets Stenion does not score. |
 | `GET /api/v1/protocol/:id` | One protocol's detail, factors, and run history.       |
+| `GET /api/v1/health`       | Indexer freshness per protocol + one overall status.   |
 
 **The consumer-facing reference is [`API.md`](API.md)**, rendered on the site at `/docs/api`. This
 section owns the _policy_; that document owns the contract as an integrator meets it — request and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,8 @@ One Vercel project = the `dashboard`. A page that renders a repo-root markdown f
 → `METHODOLOGY.md`, `/docs/api` → `API.md`) **must** have an `outputFileTracingIncludes` entry in
 `next.config.mjs` — the file is outside the dashboard dir, and without it the route works in
 `next dev` and fails only in production. The API lives as Next.js Route Handlers
-(`/api/v1/protocols`, `/api/v1/coverage`, `/api/v1/protocol/[id]` — versioned; there are **no**
+(`/api/v1/protocols`, `/api/v1/coverage`, `/api/v1/protocol/[id]`, `/api/v1/health` — versioned;
+there are **no**
 unversioned paths, the
 former transitional aliases were removed and now 404, and the versioning policy lives in
 `ARCHITECTURE.md`); the dashboard's own pages read `@stenion/db`'s `Store`
@@ -151,10 +152,12 @@ in-process (no HTTP hop). The indexer is triggered by a secret-gated cron route
 this repo** — there is no workflow or `vercel.json` `crons` entry to find. `@stenion/api` is legacy —
 kept but not deployed. Env vars: `DATABASE_URL` (Neon pooled), `STENION_RPC_URL`,
 `STENION_HORIZON_URL`, `CRON_SECRET`, plus optional `STENION_ALERT_WEBHOOK_URL` (indexer failure
-alerts; unset = off), `STENION_RATE_LIMIT_SALT`, and the retry/threshold and rate-limit knobs, which
-all have defaults. Every variable the repo understands is documented in `.env.example`.
+alerts; unset = off), `STENION_RATE_LIMIT_SALT`, and the retry/threshold, rate-limit and
+health-threshold knobs, which all have defaults. Every variable the repo understands is documented in `.env.example`.
 
-The three `/v1` read routes are CDN-cached and rate limited; the cron route is **neither**, and must
+All four `/v1` read routes are rate limited. Three are CDN-cached; `/v1/health` deliberately is
+**not** (`no-store`) — staleness there advances with the wall clock, so any TTL can serve a
+`healthy` 200 after the true answer became `degraded`. The cron route is **neither**, and must
 stay that way — rate limiting an authenticated internal trigger can only block a scheduled run.
 Caching there is meaningless (it's a POST that does work). The rate limiter's counter lives in
 Postgres because serverless has no shared memory, and it **fails open**: a limiter that can 429 the

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ pnpm --filter @stenion/dashboard dev             # http://localhost:3000
 
 The dashboard reads Postgres in-process, so once step 4 has landed at least one row you'll see
 real scores at `http://localhost:3000`. The public API is served by the dashboard at
-`/api/v1/protocols`, `/api/v1/coverage`, and `/api/v1/protocol/:id` — versioned, with the policy in
-[`ARCHITECTURE.md`](ARCHITECTURE.md#api-versioning).
+`/api/v1/protocols`, `/api/v1/coverage`, `/api/v1/protocol/:id`, and `/api/v1/health` — versioned,
+with the policy in [`ARCHITECTURE.md`](ARCHITECTURE.md#api-versioning).
 
 ### Using the public API
 
-**The full reference is [`API.md`](API.md)** — all three endpoints with live example responses, the
+**The full reference is [`API.md`](API.md)** — every endpoint with live example responses, the
 `ok`/`failed` history union, the staleness model, error shapes, and the versioning commitment. It's
 also rendered on the site at [/docs/api](https://stenion.vercel.app/docs/api). The summary:
 
@@ -119,6 +119,60 @@ which is what makes that workable in practice. If you're building something that
 more, open an issue — the numbers are policy, not physics. Full reasoning, and what the limiter
 does and doesn't protect against, is in
 [`ARCHITECTURE.md`](ARCHITECTURE.md#caching-and-rate-limits).
+
+### Is the data fresh? — `GET /api/v1/health`
+
+Stenion's worst failure mode is quiet: if the indexer stops, the site keeps serving last-known
+scores, every page renders, nothing 500s, and the numbers just age. `/api/v1/health` gives that a
+machine-readable signal so you don't have to trust a timestamp in the UI.
+
+```bash
+curl -i https://stenion.vercel.app/api/v1/health
+```
+
+```json
+{
+  "status": "degraded",
+  "thresholdMinutes": 30,
+  "protocols": [
+    {
+      "id": "blend",
+      "lastSuccessfulRunAt": "2026-08-22T12:41:00.000Z",
+      "lastRunAt": "2026-08-22T12:41:00.000Z",
+      "lastRunStatus": "ok",
+      "staleMinutes": 9
+    },
+    {
+      "id": "kinetic",
+      "lastSuccessfulRunAt": "2026-08-22T09:10:00.000Z",
+      "lastRunAt": "2026-08-22T12:49:00.000Z",
+      "lastRunStatus": "failed",
+      "staleMinutes": 220
+    }
+  ]
+}
+```
+
+Three things to know:
+
+- **`status` has three values, and the non-healthy two both answer `503`.** So an uptime monitor
+  can point at this URL and needs no body parsing at all. `healthy` = every protocol scored
+  successfully within the threshold (`200`). `degraded` = some are current and some aren't — read
+  the per-protocol rows, it's probably one adapter. `down` = nothing is current anywhere, i.e. the
+  indexer itself looks dead.
+- **`staleMinutes` is measured from `lastSuccessfulRunAt`, never from `lastRunAt`.** An adapter
+  failing every five minutes has a perpetually fresh `lastRunAt`; measuring from it would report
+  the exact failure this endpoint is for as perfectly healthy. The two timestamps together are the
+  useful signal — a fresh `lastRunAt` beside a stale `lastSuccessfulRunAt` is one broken adapter,
+  and both stale together is the cron not arriving.
+- **It is never cached.** Unlike the other routes, this one sends `Cache-Control: no-store` — a
+  health check that can be stale is a contradiction. It is still rate limited like everything else,
+  which at 60/min is ~30× more than a monitor probing every 30 seconds needs.
+
+`thresholdMinutes` is echoed in the body so you can see what number produced the verdict. It
+defaults to 30 (six missed cycles at the ~5-minute indexer cadence) and is configurable via
+`STENION_HEALTH_STALE_MINUTES`. Full reasoning for both thresholds is in
+[`ARCHITECTURE.md`](ARCHITECTURE.md#the-health-endpoint).
 
 To smoke-test the deployed 404 behaviour for an unknown protocol id, run:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,19 @@ commitment — priorities shift as protocols launch and as the project finds fun
   hidden**: a run that ultimately fails is still recorded as `failed`. The consecutive-failure
   streak is derived from `risk_scores` rather than stored in a counter, so it needs no new table and
   cannot disagree with the history it describes. See [`ARCHITECTURE.md`](ARCHITECTURE.md).
+- **A public freshness endpoint — `GET /api/v1/health`.** The failure-alerting above covers an
+  adapter failing repeatedly; it cannot cover the indexer not running at all, because nothing runs
+  to notice. There was previously no way to tell the difference short of querying Neon or eyeballing
+  a timestamp in the UI, and the site keeps serving last-known scores either way. The endpoint
+  publishes per-protocol run freshness and one overall status, and answers **503** when that status
+  is not `healthy`, so an uptime monitor consumes it without parsing a body. Three states rather
+  than a boolean, because "one adapter is broken" and "the pipeline is dead" need different first
+  moves: `degraded` says read the rows, `down` says go look at the cron. Staleness is measured from
+  each protocol's last **successful** run — measuring from the last run of any status would report
+  an adapter failing every five minutes as perpetually fresh. Needed **no schema change**: it reuses
+  the same two LATERAL subqueries the leaderboard already runs, one query, no fan-out. Thresholds
+  are configurable (`STENION_HEALTH_STALE_MINUTES`, default 30) and sit above the alert threshold so
+  the webhook fires before the monitor goes red. See [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - **Public API documentation.** [`API.md`](API.md), rendered on the site at `/docs/api`. Until now
   the only way to learn the contract was reading the route handlers on GitHub, which is a barrier
   for exactly the wallet-integrator audience the API exists for. Covers every endpoint with live

--- a/dashboard/app/api/_health.test.ts
+++ b/dashboard/app/api/_health.test.ts
@@ -1,0 +1,354 @@
+// Tests for the health endpoint's policy — staleness, the three states, and the
+// HTTP status each one is served with.
+//
+// WHY THESE EXIST: this endpoint's whole job is to be correct at the exact moment
+// nobody is looking at it, and every one of its interesting states is one we have
+// never seen. `risk_scores` has held zero `failed` rows in production (see
+// db/src/store.test.ts), so `degraded` and `down` have never once been produced
+// by real data — and by construction they never will be until the day they
+// matter. A wrong threshold or an inverted comparison here shows up as an
+// endpoint that answers `healthy` with a 200 through an outage, which is worse
+// than not having the endpoint at all: it converts "nobody was watching" into
+// "the monitor said it was fine".
+//
+// These test the policy, not the SQL. Which rows come back is the query's job
+// (db/src/store.ts, one query, covered by the integration suite); what they mean
+// is pure, and this is it.
+//
+// Run with: pnpm --filter @stenion/dashboard test
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  DEFAULT_DOWN_MULTIPLIER,
+  DEFAULT_HEALTH_SETTINGS,
+  DEFAULT_STALE_MINUTES,
+  buildHealthBody,
+  healthHttpStatus,
+  minutesSince,
+  overallStatus,
+  readHealthSettings,
+  type HealthSettings,
+  type RunFreshness,
+} from './_health.ts';
+
+const NOW = Date.parse('2026-08-22T12:50:00.000Z');
+
+/** An ISO timestamp `minutes` old relative to NOW. */
+const agedBy = (minutes: number) => new Date(NOW - minutes * 60_000).toISOString();
+
+/**
+ * A protocol whose last successful run was `staleMinutes` ago and whose last run
+ * of any status succeeded — i.e. the ordinary case.
+ */
+const fresh = (id: string, staleMinutes: number): RunFreshness => ({
+  id,
+  lastSuccessfulRunAt: agedBy(staleMinutes),
+  lastRunAt: agedBy(staleMinutes),
+  lastRunStatus: 'ok',
+});
+
+/**
+ * A protocol the indexer is still reaching but whose adapter is failing: the
+ * last run is recent and failed, the last SUCCESS is `staleMinutes` old.
+ */
+const failing = (id: string, staleMinutes: number): RunFreshness => ({
+  id,
+  lastSuccessfulRunAt: agedBy(staleMinutes),
+  lastRunAt: agedBy(1),
+  lastRunStatus: 'failed',
+});
+
+/** A protocol that has never produced a successful run. */
+const neverSucceeded = (id: string): RunFreshness => ({
+  id,
+  lastSuccessfulRunAt: null,
+  lastRunAt: null,
+  lastRunStatus: null,
+});
+
+const build = (rows: RunFreshness[], settings: HealthSettings = DEFAULT_HEALTH_SETTINGS) =>
+  buildHealthBody(rows, settings, NOW);
+
+// ---------------------------------------------------------------------------
+
+describe('the three acceptance-criteria cases', () => {
+  it('all protocols current → healthy, 200', () => {
+    const body = build([fresh('blend', 2), fresh('blend-yieldblox', 3), fresh('kinetic', 4)]);
+    assert.equal(body.status, 'healthy');
+    assert.equal(healthHttpStatus(body.status), 200);
+  });
+
+  it('one protocol stale, the rest current → degraded, non-200', () => {
+    // The isolated-adapter case: the cron is demonstrably arriving, because two
+    // protocols scored minutes ago. Only one is behind.
+    const body = build([fresh('blend', 2), fresh('blend-yieldblox', 3), failing('kinetic', 213)]);
+    assert.equal(body.status, 'degraded');
+    assert.notEqual(healthHttpStatus(body.status), 200);
+    assert.equal(healthHttpStatus(body.status), 503);
+  });
+
+  it('nothing has succeeded in a long time → down, non-200', () => {
+    // The infrastructure case: every protocol is past the down window, so there
+    // is no evidence the cron is arriving at all.
+    const body = build([fresh('blend', 400), fresh('blend-yieldblox', 400), fresh('kinetic', 400)]);
+    assert.equal(body.status, 'down');
+    assert.notEqual(healthHttpStatus(body.status), 200);
+    assert.equal(healthHttpStatus(body.status), 503);
+  });
+
+  it('no protocol has ever run → down', () => {
+    // A migrated but never-indexed database. There is nothing to measure a down
+    // window from, and 200 would make this endpoint's very first answer a false
+    // negative.
+    const body = build([neverSucceeded('blend'), neverSucceeded('kinetic')]);
+    assert.equal(body.status, 'down');
+    assert.equal(healthHttpStatus(body.status), 503);
+  });
+});
+
+describe('the boundary between degraded and down', () => {
+  // Both are non-200, so nothing about *alerting* turns on this. What turns on
+  // it is where an operator is sent: `degraded` says read the per-protocol rows,
+  // `down` says go look at the cron. Getting it backwards wastes the first ten
+  // minutes of an incident.
+
+  it('holds at degraded while everything is stale but inside the down window', () => {
+    const insideWindow = DEFAULT_STALE_MINUTES * DEFAULT_DOWN_MULTIPLIER - 1;
+    const body = build([fresh('blend', insideWindow), fresh('kinetic', insideWindow)]);
+    assert.equal(body.status, 'degraded');
+  });
+
+  it('is still degraded exactly ON the down window, not yet down', () => {
+    // `>` not `>=`: the boundary minute belongs to the milder claim. Declaring
+    // the cron dead is the more specific accusation, so it takes the later side.
+    const onWindow = DEFAULT_STALE_MINUTES * DEFAULT_DOWN_MULTIPLIER;
+    assert.equal(build([fresh('blend', onWindow)]).status, 'degraded');
+  });
+
+  it('becomes down one minute past it', () => {
+    const pastWindow = DEFAULT_STALE_MINUTES * DEFAULT_DOWN_MULTIPLIER + 1;
+    assert.equal(build([fresh('blend', pastWindow)]).status, 'down');
+  });
+
+  it('measures the down window from the FRESHEST success, not the oldest', () => {
+    // The most generous reading available, so this can never report worse than
+    // the truth. One protocol 400 minutes stale does not make the system `down`
+    // while another succeeded 35 minutes ago — that is 7 missed cycles, bad, but
+    // it is evidence the cron IS arriving.
+    const body = build([fresh('blend', 35), fresh('kinetic', 400)]);
+    assert.equal(body.status, 'degraded');
+  });
+
+  it('never lets a never-succeeded protocol drag the window earlier', () => {
+    // A null staleMinutes is not an age and must not be treated as an infinite
+    // one. Here a protocol that has never scored sits next to one that is stale
+    // but inside the window; the state is degraded, on the evidence that exists.
+    const insideWindow = DEFAULT_STALE_MINUTES * DEFAULT_DOWN_MULTIPLIER - 1;
+    const body = build([neverSucceeded('new-adapter'), fresh('blend', insideWindow)]);
+    assert.equal(body.status, 'degraded');
+  });
+});
+
+describe('the staleness threshold itself', () => {
+  it('counts a protocol exactly on the threshold as current', () => {
+    // Inclusive, so `staleMinutes <= thresholdMinutes` is the documented rule and
+    // the endpoint does not flicker for the minute it sits on the boundary.
+    assert.equal(build([fresh('blend', DEFAULT_STALE_MINUTES)]).status, 'healthy');
+  });
+
+  it('counts one minute past it as not current', () => {
+    assert.equal(build([fresh('blend', DEFAULT_STALE_MINUTES + 1)]).status, 'degraded');
+  });
+
+  it('sits above the indexer alert threshold, so the webhook fires first', () => {
+    // The intended escalation order, asserted rather than left to a comment: the
+    // indexer alerts after 4 consecutive failures (~20 min at the 5-minute
+    // cadence), and only if the problem is still there does the monitor go red.
+    // If someone lowers this below 20, this test says so.
+    const alertThresholdMinutes = 4 * 5;
+    assert.ok(
+      DEFAULT_STALE_MINUTES > alertThresholdMinutes,
+      `health threshold (${DEFAULT_STALE_MINUTES}m) must exceed the indexer alert threshold ` +
+        `(${alertThresholdMinutes}m), or the monitor pages before the webhook mentions it`,
+    );
+  });
+
+  it('is at least a few cycles wide, so one slow cycle is not an outage', () => {
+    const cadenceMinutes = 5;
+    assert.ok(DEFAULT_STALE_MINUTES >= cadenceMinutes * 3);
+  });
+});
+
+describe('staleness is measured from the last SUCCESSFUL run', () => {
+  it('does not let a fresh failed run disguise stale data', () => {
+    // THE INVARIANT, and the reason the two timestamps are separate fields.
+    //
+    // An adapter failing reliably every five minutes has a `lastRunAt` that is
+    // always one minute old. Measuring freshness from it would report that
+    // protocol as perfectly current forever — inverted, and precisely the case
+    // this endpoint is for.
+    const body = build([failing('kinetic', 213)]);
+    const kinetic = body.protocols[0];
+    assert.equal(kinetic?.staleMinutes, 213);
+    assert.equal(kinetic?.lastRunStatus, 'failed');
+    assert.equal(body.status, 'down');
+  });
+
+  it('reports a recent failure as healthy while the last success is current', () => {
+    // Deliberate: the indexer already retried 3 times before recording this, but
+    // it is still one cycle, and the served data is 4 minutes old. Paging here
+    // would be a false page. Sustained failure is not missed — it crosses the
+    // threshold on its own within THRESHOLD minutes.
+    const body = build([failing('kinetic', 4), fresh('blend', 2)]);
+    assert.equal(body.status, 'healthy');
+    assert.equal(healthHttpStatus(body.status), 200);
+    // ...and the failure is still visible to a consumer that wants to act on it.
+    assert.equal(body.protocols.find((p) => p.id === 'kinetic')?.lastRunStatus, 'failed');
+  });
+});
+
+describe('the published body', () => {
+  it('carries every documented field per protocol', () => {
+    const body = build([failing('kinetic', 213)]);
+    assert.deepEqual(body.protocols, [
+      {
+        id: 'kinetic',
+        lastSuccessfulRunAt: agedBy(213),
+        lastRunAt: agedBy(1),
+        lastRunStatus: 'failed',
+        staleMinutes: 213,
+      },
+    ]);
+  });
+
+  it('publishes lastRunStatus as ok/failed, matching the other /v1 routes', () => {
+    // NOT `success`/`failure`. The same underlying column is published as
+    // `ok`/`failed` on /v1/protocols and /v1/protocol/:id, and one field name
+    // carrying two vocabularies across a single API is a bug a consumer only
+    // finds in production.
+    const body = build([fresh('blend', 1), failing('kinetic', 99)]);
+    for (const protocol of body.protocols) {
+      assert.ok(
+        protocol.lastRunStatus === 'ok' ||
+          protocol.lastRunStatus === 'failed' ||
+          protocol.lastRunStatus === null,
+        `unexpected lastRunStatus: ${String(protocol.lastRunStatus)}`,
+      );
+    }
+  });
+
+  it('echoes the threshold it judged against', () => {
+    // So a consumer reading `degraded` can tell what number produced it without
+    // knowing our environment configuration.
+    const settings: HealthSettings = { thresholdMinutes: 12, downMultiplier: 3 };
+    assert.equal(build([fresh('blend', 1)], settings).thresholdMinutes, 12);
+  });
+
+  it('preserves the order the query returned, without re-sorting', () => {
+    const body = build([fresh('kinetic', 1), fresh('blend', 2), fresh('yieldblox', 3)]);
+    assert.deepEqual(
+      body.protocols.map((p) => p.id),
+      ['kinetic', 'blend', 'yieldblox'],
+    );
+  });
+
+  it('gives a never-succeeded protocol null, never zero', () => {
+    // A zero would render as "just ran", the exact inverse of never having run.
+    const body = build([neverSucceeded('blend')]);
+    assert.equal(body.protocols[0]?.staleMinutes, null);
+    assert.equal(body.protocols[0]?.lastSuccessfulRunAt, null);
+  });
+
+  it('is down for an empty registry rather than vacuously healthy', () => {
+    const body = build([]);
+    assert.equal(body.status, 'down');
+    assert.deepEqual(body.protocols, []);
+    assert.equal(healthHttpStatus(body.status), 503);
+  });
+});
+
+describe('minutesSince', () => {
+  it('floors, so the number means "at least this old"', () => {
+    assert.equal(minutesSince(new Date(NOW - 119_000).toISOString(), NOW), 1);
+  });
+
+  it('clamps clock skew to zero rather than reporting a negative age', () => {
+    // Neon's now() and the function's clock are different clocks; a run stamped
+    // slightly in the future is fresh, not -1 minutes old.
+    assert.equal(minutesSince(new Date(NOW + 30_000).toISOString(), NOW), 0);
+  });
+
+  it('returns null for a missing or unparseable timestamp', () => {
+    assert.equal(minutesSince(null, NOW), null);
+    assert.equal(minutesSince('not a date', NOW), null);
+  });
+
+  it('treats an unparseable timestamp as not current, never as fresh', () => {
+    const body = build([
+      { id: 'blend', lastSuccessfulRunAt: 'garbage', lastRunAt: 'garbage', lastRunStatus: 'ok' },
+    ]);
+    assert.equal(body.protocols[0]?.staleMinutes, null);
+    assert.equal(body.status, 'down');
+  });
+});
+
+describe('readHealthSettings', () => {
+  it('defaults when nothing is set', () => {
+    assert.deepEqual(readHealthSettings({}), DEFAULT_HEALTH_SETTINGS);
+  });
+
+  it('reads both knobs from the environment — the threshold is not hardcoded', () => {
+    assert.deepEqual(
+      readHealthSettings({
+        STENION_HEALTH_STALE_MINUTES: '10',
+        STENION_HEALTH_DOWN_MULTIPLIER: '4',
+      }),
+      { thresholdMinutes: 10, downMultiplier: 4 },
+    );
+  });
+
+  it('falls back rather than throwing on a malformed value', () => {
+    // A health endpoint that 500s because someone typed `thirty` reports an
+    // outage that does not exist, most likely at deploy time — when a real one
+    // is both most likely and least distinguishable.
+    for (const bad of ['thirty', '', '   ', '-5', '0', 'NaN', 'Infinity']) {
+      assert.equal(
+        readHealthSettings({ STENION_HEALTH_STALE_MINUTES: bad }).thresholdMinutes,
+        DEFAULT_STALE_MINUTES,
+        `expected fallback for ${JSON.stringify(bad)}`,
+      );
+    }
+  });
+
+  it('accepts a fractional threshold', () => {
+    // Not expected in production, but positive-and-finite is the documented rule
+    // and it should not silently become the default.
+    assert.equal(readHealthSettings({ STENION_HEALTH_STALE_MINUTES: '2.5' }).thresholdMinutes, 2.5);
+  });
+});
+
+describe('overallStatus is a pure function of the rows it is given', () => {
+  it('does not depend on the order protocols arrive in', () => {
+    const rows = [fresh('a', 1), fresh('b', 400), neverSucceeded('c')];
+    const forwards = buildHealthBody(rows, DEFAULT_HEALTH_SETTINGS, NOW).status;
+    const backwards = buildHealthBody([...rows].reverse(), DEFAULT_HEALTH_SETTINGS, NOW).status;
+    assert.equal(forwards, backwards);
+  });
+
+  it('measures every protocol against one instant', () => {
+    // `nowMs` is a parameter, not a Date.now() per protocol, so a slow response
+    // cannot report ages that disagree with each other.
+    const body = build([fresh('a', 5), fresh('b', 5), fresh('c', 5)]);
+    assert.deepEqual(
+      body.protocols.map((p) => p.staleMinutes),
+      [5, 5, 5],
+    );
+  });
+
+  it('exposes overallStatus directly for callers that already have the rows', () => {
+    const protocols = build([fresh('a', 1)]).protocols;
+    assert.equal(overallStatus(protocols, DEFAULT_HEALTH_SETTINGS), 'healthy');
+  });
+});

--- a/dashboard/app/api/_health.ts
+++ b/dashboard/app/api/_health.ts
@@ -1,0 +1,299 @@
+// Health POLICY for the public API: what "stale" means, what the three overall
+// states mean, and which HTTP status each one is served with.
+//
+// Like ./_http, ./_cache and ./_rate-limit this is a LEAF — it imports nothing at
+// all — so it is loadable from a plain Node test under native type stripping. The
+// database half is @stenion/db's `listRunHealth()`; the wiring is the route.
+//
+// It deliberately does not import `RunHealthEntry` from @stenion/db, even as a
+// type: the input below is declared structurally so this module has no import
+// graph whatsoever. `RunFreshness` and `RunHealthEntry` are the same shape, and
+// the route passing one where the other is expected is what typechecks that.
+//
+// ---------------------------------------------------------------------------
+// WHY THIS ENDPOINT EXISTS
+//
+// Scoring silently stopping is one of the worst failure modes Stenion has. The
+// site keeps serving last-known scores, every page renders, nothing 500s, and
+// the numbers quietly age. There is no red anywhere — the only symptoms are a
+// timestamp in the UI that a human has to notice and compare against a clock,
+// and a database nobody is watching. This gives that failure a machine-readable
+// signal and a non-200, so an uptime monitor can catch it without a human in the
+// loop and without parsing a body.
+//
+// ---------------------------------------------------------------------------
+// STALENESS IS MEASURED FROM THE LAST *SUCCESSFUL* RUN, NOT THE LAST RUN
+//
+// A failed run produced no score. Measuring freshness from `lastRunAt` would let
+// an adapter that fails reliably every five minutes report as perfectly fresh
+// forever, which is precisely inverted: a protocol failing like clockwork is the
+// case this endpoint is for. So `staleMinutes` is the age of the newest `ok` run
+// and nothing else.
+//
+// `lastRunAt`/`lastRunStatus` are still published per protocol, because together
+// with the above they say WHERE the problem is:
+//
+//   fresh lastRunAt + stale lastSuccessfulRunAt → the cron is arriving, this
+//     protocol's adapter is failing. One adapter, isolated. Go read its error.
+//   both stale                                  → the cron is not arriving at
+//     all. Infrastructure. Go look at cron-job.org.
+//
+// ---------------------------------------------------------------------------
+// WHY A FRESH FAILURE ALONE IS NOT UNHEALTHY
+//
+// A protocol whose newest run failed but whose newest *success* is four minutes
+// old is reported `healthy`, and that is deliberate rather than an oversight.
+//
+// The indexer already retries (STENION_RETRY_ATTEMPTS, default 3) before it will
+// record a failure at all, so a `failed` row is three exhausted attempts — but it
+// is still one cycle, and the data it protects is four minutes old. Turning the
+// endpoint red there means paging someone about a blip while the served numbers
+// are entirely current. Repeated failure is not missed by this: an adapter that
+// keeps failing stops producing successful runs, and crosses the threshold below
+// on its own within THRESHOLD minutes. Sustained failure and staleness are the
+// same event seen at different times, so staleness alone is enough to catch it —
+// with the transient case filtered out for free.
+//
+// A consumer who genuinely wants to know about any single failed cycle reads
+// `lastRunStatus` in the body, which is why it is published.
+// ---------------------------------------------------------------------------
+
+/**
+ * How old a protocol's newest successful run may be before it stops counting as
+ * current, in minutes. Overridable with `STENION_HEALTH_STALE_MINUTES`.
+ *
+ * 30 minutes = SIX missed cycles at the indexer's 5-minute cadence.
+ *
+ * Sized against what already exists rather than picked round. The indexer's
+ * failure-alert threshold is 4 consecutive cycles (`STENION_ALERT_THRESHOLD`,
+ * ~20 minutes), and its stated reasoning is that "a score 20 minutes stale is
+ * not an emergency — false pages are how people learn to ignore alerts". This
+ * endpoint is consumed by an uptime monitor, so its non-200 is a *louder* signal
+ * than that webhook, and it must therefore sit at a *higher* bar. 30 > 20 gives
+ * the intended escalation order: the webhook mentions it first, and only if the
+ * problem is still there ten minutes later does the monitor go red.
+ *
+ * The floor on this number is set by the cadence: anything under ~10 minutes
+ * would make a single slow cycle, a Vercel cold start, or one cron-job.org
+ * misfire read as an outage.
+ */
+export const DEFAULT_STALE_MINUTES = 30;
+
+/**
+ * How many multiples of the staleness threshold pass, with NOTHING succeeding
+ * anywhere, before the overall state is `down` rather than `degraded`.
+ * Overridable with `STENION_HEALTH_DOWN_MULTIPLIER`.
+ *
+ * 2 → 60 minutes, i.e. twelve missed cycles with not one successful run across
+ * the entire registry.
+ *
+ * WHY THERE IS A SECOND, LONGER WINDOW AT ALL. "Every protocol is stale at once"
+ * is strong evidence of infrastructure rather than N simultaneous adapter bugs,
+ * and it is tempting to call that `down` immediately. Two things argue against
+ * doing so at the same threshold. First, the shared dependencies — Soroban RPC
+ * and Horizon — are shared by every adapter, so a broad upstream outage takes
+ * all of them out together while our own infrastructure is entirely fine;
+ * calling that "the cron is dead" sends an operator to the wrong place. Second,
+ * a registry this small (three targets today, and one adapter serving several of
+ * them) makes "all of them" a much weaker signal than it sounds: with a single
+ * protocol listed, "all stale" and "one adapter broken" are the same observation.
+ *
+ * Doubling the window costs nothing operationally, because `degraded` is ALSO
+ * non-200 — a monitor has already fired by then. All the extra 30 minutes buys
+ * is the confidence to say which thing broke, which is the only thing the label
+ * is for.
+ */
+export const DEFAULT_DOWN_MULTIPLIER = 2;
+
+/**
+ * The overall state.
+ *
+ * Three values rather than a boolean because "unhealthy" conflates two problems
+ * with different owners and different fixes: one adapter failing while the rest
+ * are current is a code bug in one file, and nothing succeeding anywhere is the
+ * pipeline being down. A single flag makes an operator open the body to find out
+ * which, which defeats the point of having a status at all.
+ */
+export type HealthStatus = 'healthy' | 'degraded' | 'down';
+
+/** Threshold configuration, read from the environment. */
+export interface HealthSettings {
+  thresholdMinutes: number;
+  downMultiplier: number;
+}
+
+export const DEFAULT_HEALTH_SETTINGS: HealthSettings = {
+  thresholdMinutes: DEFAULT_STALE_MINUTES,
+  downMultiplier: DEFAULT_DOWN_MULTIPLIER,
+};
+
+/**
+ * What the store hands us per protocol. Structurally identical to @stenion/db's
+ * `RunHealthEntry` — declared here rather than imported so this module keeps an
+ * empty import graph. See the header.
+ */
+export interface RunFreshness {
+  id: string;
+  lastSuccessfulRunAt: string | null;
+  lastRunAt: string | null;
+  lastRunStatus: 'ok' | 'failed' | null;
+}
+
+/** One protocol as `GET /api/v1/health` publishes it. */
+export interface HealthProtocol {
+  id: string;
+  lastSuccessfulRunAt: string | null;
+  lastRunAt: string | null;
+  lastRunStatus: 'ok' | 'failed' | null;
+  /**
+   * Minutes since `lastSuccessfulRunAt`, computed at request time and never
+   * stored. Null when the protocol has never scored successfully — null is
+   * "there is no successful run to measure from", NOT zero, which would read as
+   * perfectly fresh and is the exact inversion of the truth.
+   */
+  staleMinutes: number | null;
+}
+
+/** The `GET /api/v1/health` body. */
+export interface HealthBody {
+  status: HealthStatus;
+  /** Echoed so a consumer can see what the number it is being judged against is. */
+  thresholdMinutes: number;
+  protocols: HealthProtocol[];
+}
+
+/** A finite positive number from an env string, or undefined if it isn't one. */
+function positiveNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+  const value = Number(trimmed);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Read the thresholds from the environment.
+ *
+ * Mirrors `readRateLimitSettings` in ./_rate-limit exactly, including taking the
+ * environment as an argument so it is testable, and including the treatment of a
+ * malformed value: fall back to the default rather than throw. A health endpoint
+ * that 500s because someone typed `STENION_HEALTH_STALE_MINUTES=thirty` reports
+ * an outage that does not exist, and it does so most convincingly at the moment
+ * of a deploy — when a real one is most likely and least distinguishable.
+ */
+export function readHealthSettings(
+  env: Record<string, string | undefined> = process.env,
+): HealthSettings {
+  return {
+    thresholdMinutes: positiveNumber(env.STENION_HEALTH_STALE_MINUTES) ?? DEFAULT_STALE_MINUTES,
+    downMultiplier: positiveNumber(env.STENION_HEALTH_DOWN_MULTIPLIER) ?? DEFAULT_DOWN_MULTIPLIER,
+  };
+}
+
+/**
+ * Whole minutes between an ISO timestamp and now, or null if there isn't one.
+ *
+ * Floored, so `staleMinutes: 30` means "at least 30 minutes", and clamped at 0:
+ * a run stamped slightly in the future (clock skew between Neon's `now()` and
+ * the function's) is fresh, not negative. An unparseable timestamp returns null
+ * — the same answer as "never ran", because in both cases we cannot say how old
+ * the data is, and inventing a number would be worse than admitting that.
+ */
+export function minutesSince(iso: string | null, nowMs: number): number | null {
+  if (iso === null) return null;
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((nowMs - ms) / 60_000));
+}
+
+/**
+ * Is this protocol producing current data?
+ *
+ * Never having succeeded is NOT current. That is worth stating because elsewhere
+ * in Stenion a never-scored protocol (`safetyScore: null`) means "our pipeline
+ * has not got there yet" and is deliberately not treated as a bad result. Here
+ * the question is different and narrower: this endpoint asks whether the
+ * pipeline is producing data for this row, and for a row that has never produced
+ * any, the answer is no. It carries no judgement about the protocol.
+ */
+export function isCurrent(protocol: HealthProtocol, thresholdMinutes: number): boolean {
+  return protocol.staleMinutes !== null && protocol.staleMinutes <= thresholdMinutes;
+}
+
+/**
+ * The per-protocol rows plus the thresholds → the overall state.
+ *
+ *   healthy   every protocol is current.
+ *   degraded  at least one is current and at least one is not — so the pipeline
+ *             is demonstrably running and something specific is wrong. Also the
+ *             state when everything is stale but not yet past the down window.
+ *   down      nothing is current anywhere and the newest success across the whole
+ *             registry is older than thresholdMinutes × downMultiplier.
+ *
+ * An EMPTY registry is `down`, not `healthy`. Vacuous truth is the wrong answer
+ * for a probe: "no protocols are stale because there are no protocols" is a
+ * database that has been migrated but never indexed, or one pointed at the wrong
+ * connection string, and reporting 200 for it would make the endpoint's first
+ * ever answer a false negative.
+ */
+export function overallStatus(protocols: HealthProtocol[], settings: HealthSettings): HealthStatus {
+  if (protocols.length === 0) return 'down';
+
+  const current = protocols.filter((p) => isCurrent(p, settings.thresholdMinutes));
+  if (current.length === protocols.length) return 'healthy';
+  if (current.length > 0) return 'degraded';
+
+  // Nothing is current. How long has that been true? The freshest success
+  // anywhere is the most generous reading available, so measuring the down
+  // window from it cannot make things look worse than they are.
+  const ages = protocols.map((p) => p.staleMinutes).filter((m): m is number => m !== null);
+  if (ages.length === 0) return 'down'; // nothing has EVER succeeded
+
+  const downAfterMinutes = settings.thresholdMinutes * settings.downMultiplier;
+  return Math.min(...ages) > downAfterMinutes ? 'down' : 'degraded';
+}
+
+/**
+ * The HTTP status for an overall state.
+ *
+ * `degraded` and `down` are BOTH 503, so an uptime monitor that only reads the
+ * status line catches either without parsing the body — which is the acceptance
+ * criterion this endpoint exists to satisfy. The distinction between them is for
+ * the human who then opens it, and is carried in `status`, not in the code.
+ *
+ * 503 rather than 500: nothing has errored. The route did its job, queried
+ * successfully, and is telling the truth about a pipeline that is behind. 503 is
+ * the status that means exactly that, and it is what monitors and load balancers
+ * already understand as "not serving correct data right now, try again".
+ */
+export function healthHttpStatus(status: HealthStatus): number {
+  return status === 'healthy' ? 200 : 503;
+}
+
+/**
+ * Store rows + settings + the clock → the response body.
+ *
+ * `nowMs` is a parameter rather than a call to `Date.now()` inside, so every
+ * protocol in one response is measured against ONE instant. Reading the clock
+ * per protocol would let a slow response report ages that disagree with each
+ * other, and would make the whole thing untestable.
+ */
+export function buildHealthBody(
+  rows: readonly RunFreshness[],
+  settings: HealthSettings,
+  nowMs: number = Date.now(),
+): HealthBody {
+  const protocols: HealthProtocol[] = rows.map((row) => ({
+    id: row.id,
+    lastSuccessfulRunAt: row.lastSuccessfulRunAt,
+    lastRunAt: row.lastRunAt,
+    lastRunStatus: row.lastRunStatus,
+    staleMinutes: minutesSince(row.lastSuccessfulRunAt, nowMs),
+  }));
+
+  return {
+    status: overallStatus(protocols, settings),
+    thresholdMinutes: settings.thresholdMinutes,
+    protocols,
+  };
+}

--- a/dashboard/app/api/_http.ts
+++ b/dashboard/app/api/_http.ts
@@ -6,10 +6,10 @@
 // module deliberately imports nothing: it is the part of the response contract
 // that is pure, and therefore the part worth pinning.
 
-// CORS for the PUBLIC data routes only. Stenion's /v1/protocols, /v1/coverage and
-// /v1/protocol/:id serve public, read-only, payment-blind data — any origin may read
-// them (a wallet, a third-party dashboard, anyone), so `*` is the correct, simplest
-// policy, carried over verbatim from the standalone @stenion/api. NOTE: the Stenion
+// CORS for the PUBLIC data routes only. Stenion's /v1/protocols, /v1/coverage,
+// /v1/protocol/:id and /v1/health serve public, read-only, payment-blind data — any
+// origin may read them (a wallet, a third-party dashboard, anyone), so `*` is the
+// correct, simplest policy, carried over verbatim from the standalone @stenion/api. NOTE: the Stenion
 // dashboard's own pages do NOT rely on this — they read the Store in-process (see
 // app/lib/api.ts), never cross-origin. CORS here is purely for external browser
 // clients. The cron route deliberately gets NO CORS (it's secret-gated, not public).

--- a/dashboard/app/api/v1/health/route.ts
+++ b/dashboard/app/api/v1/health/route.ts
@@ -1,0 +1,112 @@
+// GET /api/v1/health — is the indexer still producing data?
+//
+// A machine-readable freshness signal, added because there was previously no way
+// to answer that question short of querying Neon by hand or eyeballing a
+// timestamp in the UI. Scoring silently stopping is one of Stenion's worst
+// failure modes precisely because nothing goes red: the site keeps serving
+// last-known scores and every page renders fine while the numbers age.
+//
+// Follows the same skeleton as the other /v1 routes — rate limit first, one Store
+// call, jsonResponse, generic 500, OPTIONS preflight — with two deliberate
+// differences, both documented below: it is NOT CDN-cached, and it can answer
+// 503. The policy it serves (what "stale" means, the three states, which status
+// each gets) is in ../../_health.ts, which is a pure leaf so it can be tested.
+//
+// Versioned under /v1 like every other public path; see ARCHITECTURE.md
+// "API versioning". Public and unauthenticated on purpose: it publishes run
+// timestamps and nothing else — no scores, no errors, no configuration — which
+// is strictly less than /v1/protocols already exposes.
+
+import {
+  CORS_HEADERS,
+  NO_STORE,
+  PREFLIGHT_MAX_AGE_SECONDS,
+  enforceRateLimit,
+  getStore,
+  jsonResponse,
+  publicCacheControl,
+} from '../../_shared';
+import { buildHealthBody, healthHttpStatus, readHealthSettings } from '../../_health';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request): Promise<Response> {
+  // First, like every other public route: this one is cheap, but it is still a
+  // database query, and an endpoint designed to be polled is the last one that
+  // should be exempt from the limiter. At 60/min a monitor probing every 30
+  // seconds uses 2.
+  const limited = await enforceRateLimit(req);
+  if (limited) return limited;
+
+  try {
+    // ONE query — see @stenion/db's listRunHealth. Two LATERAL index walks per
+    // protocol over the index the leaderboard already uses, no score columns, no
+    // factors jsonb, no per-protocol fan-out.
+    const rows = await getStore().listRunHealth();
+    const body = buildHealthBody(rows, readHealthSettings());
+
+    // NEVER CACHED, unlike the other three /v1 routes, and this is the one place
+    // this route deliberately departs from them.
+    //
+    // ./_cache exists to stop a cached body masking `lastRunAt`/`lastRunStatus`,
+    // and it does that by expiring before the next indexer run could contradict
+    // it. That works there because the thing being hidden changes only when a run
+    // lands. Here it does not: staleness advances with the wall clock, so a body
+    // built at 29 minutes stale and cached for 45 seconds is still being served,
+    // saying `healthy` with a 200, once the true answer has become `degraded`
+    // with a 503. The window is small, but this is the endpoint whose entire
+    // purpose is to be believed about freshness — a health check that can be
+    // stale is a contradiction, not a tradeoff.
+    //
+    // The 503s must not be cached either, and for a stronger reason: the CDN
+    // cache key is the URL, so a cached 503 would go on being served to everyone
+    // after the pipeline recovered, turning a resolved incident into an ongoing
+    // one. `no-store` covers both cases with one rule.
+    //
+    // What it costs: one database round trip per request, uncushioned. Measured
+    // from a dev machine on 2026-08-22, warm: 0.4-1.1s for listRunHealth against
+    // 1.1-1.2s for the leaderboard query, both dominated by network round trip
+    // rather than by the query. So this is no more expensive than the route that
+    // IS cached, it does strictly less work per row, and it is bounded above by
+    // the rate limiter.
+    //
+    // KNOWN CAVEAT, measured rather than assumed: a COLD Neon (scaled to zero)
+    // took ~20s to answer the first query. Vercel's default route timeout is 10s,
+    // so a probe landing on a cold database gets a platform 504 instead of this
+    // route's own 503. That is left alone deliberately rather than papered over
+    // with a raised `maxDuration`. Neon only goes cold if nothing has touched it
+    // for a long while, which on this deployment means the indexer has stopped —
+    // exactly the case where the answer is "unhealthy" anyway. A monitor reads
+    // 504 and 503 the same way, so the verdict survives; only the body is lost,
+    // and buying it back would mean making every healthy probe wait longer.
+    return jsonResponse(body, healthHttpStatus(body.status), { 'cache-control': NO_STORE });
+  } catch (err) {
+    // Same generic 500 and same no-store as the other routes. Note this is NOT
+    // the unhealthy path: a 503 above means the query succeeded and the pipeline
+    // is behind, a 500 here means we could not find out. Keeping them on separate
+    // codes is what lets a monitor tell "the indexer is stopped" from "the health
+    // check itself is broken".
+    console.error('GET /api/v1/health failed:', err);
+    return jsonResponse({ error: 'Internal server error' }, 500, { 'cache-control': NO_STORE });
+  }
+}
+
+/**
+ * CORS preflight for cross-origin browser clients.
+ *
+ * Cacheable for a day and not rate limited, exactly as on the other public
+ * routes: the policy is a constant that only changes on deploy. Caching the
+ * preflight is unrelated to caching the response — the preflight answers "may I
+ * ask?", which does not go stale, not "what is the answer?", which does.
+ */
+export function OPTIONS(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...CORS_HEADERS,
+      'access-control-max-age': String(PREFLIGHT_MAX_AGE_SECONDS),
+      'cache-control': publicCacheControl(PREFLIGHT_MAX_AGE_SECONDS),
+    },
+  });
+}

--- a/dashboard/app/lib/api.ts
+++ b/dashboard/app/lib/api.ts
@@ -3,8 +3,8 @@
 // ARCHITECTURE NOTE — deploy merge (2026-08-12). The public API used to be a
 // separate @stenion/api service that this module fetched over HTTP (STENION_API_URL).
 // For the Vercel deploy the API is merged INTO this Next.js app as Route Handlers
-// (app/api/v1/protocols, app/api/v1/coverage, app/api/v1/protocol/[id]) so there is one deployable,
-// not two.
+// (app/api/v1/protocols, app/api/v1/coverage, app/api/v1/protocol/[id], app/api/v1/health) so
+// there is one deployable, not two.
 //
 // Because the dashboard renders on the server, its pages now read the same
 // @stenion/db Store DIRECTLY here — no HTTP hop, no self-fetch. Self-fetching our

--- a/db/src/index.ts
+++ b/db/src/index.ts
@@ -9,6 +9,7 @@ export {
   type HistoryEntry,
   type ProtocolDetail,
   type RecentRun,
+  type RunHealthEntry,
 } from './store';
 export {
   createRateLimiter,

--- a/db/src/store.integration.test.ts
+++ b/db/src/store.integration.test.ts
@@ -105,6 +105,74 @@ describe('Store SQL (integration)', { skip }, () => {
     assert.equal(detail.lastRunAt, '2026-08-16T10:05:00.000Z');
   });
 
+  it('separates the last successful run from the last run, for GET /api/v1/health', async () => {
+    // The health endpoint's entire signal is the gap between these two, and like
+    // the staleness model above it is SQL semantics: the `ok` LATERAL filters on
+    // status, the `latest` one does not. An in-memory Store would only test a
+    // re-implementation of that.
+    const p = id('health-failing');
+    await store.upsertProtocol({
+      id: p,
+      name: 'Failing',
+      chain: 'stellar',
+      adapterRef: 'FakeAdapter',
+    });
+    await insertRun(p, { status: 'ok', score: 53, runAt: '2026-08-16T10:00:00Z' });
+    await insertRun(p, { status: 'failed', error: 'RPC down', runAt: '2026-08-16T10:05:00Z' });
+
+    const rows = await store.listRunHealth();
+    const entry = rows.find((r) => r.id === p);
+    assert.ok(entry);
+    // The failed run must NOT advance the success timestamp — otherwise an
+    // adapter failing every cycle reports as permanently fresh.
+    assert.equal(entry.lastSuccessfulRunAt, '2026-08-16T10:00:00.000Z');
+    assert.equal(entry.lastRunAt, '2026-08-16T10:05:00.000Z');
+    assert.equal(entry.lastRunStatus, 'failed');
+  });
+
+  it('includes a protocol that has never run, rather than omitting it', async () => {
+    // LEFT JOIN LATERAL, not an inner join. A protocol missing from the health
+    // response would read as "nothing wrong here", which is the opposite of what
+    // a row with no runs means.
+    const p = id('health-never');
+    await store.upsertProtocol({
+      id: p,
+      name: 'Never',
+      chain: 'stellar',
+      adapterRef: 'FakeAdapter',
+    });
+
+    const entry = (await store.listRunHealth()).find((r) => r.id === p);
+    assert.ok(entry, 'a registered protocol with no runs must still appear');
+    assert.equal(entry.lastSuccessfulRunAt, null);
+    assert.equal(entry.lastRunAt, null);
+    assert.equal(entry.lastRunStatus, null);
+  });
+
+  it('returns exactly one row per protocol', async () => {
+    // The acceptance criterion that matters for cost: one row per protocol out of
+    // one query, no fan-out and no duplicate rows from the joins. Several runs
+    // for one protocol must still collapse to a single entry.
+    const p = id('health-many-runs');
+    await store.upsertProtocol({
+      id: p,
+      name: 'Many',
+      chain: 'stellar',
+      adapterRef: 'FakeAdapter',
+    });
+    for (const minute of ['00', '05', '10', '15']) {
+      await insertRun(p, { status: 'ok', score: 50, runAt: `2026-08-16T12:${minute}:00Z` });
+    }
+
+    const rows = await store.listRunHealth();
+    assert.equal(rows.filter((r) => r.id === p).length, 1);
+    assert.equal(
+      rows.find((r) => r.id === p)?.lastSuccessfulRunAt,
+      '2026-08-16T12:15:00.000Z',
+      'the newest ok run wins',
+    );
+  });
+
   it('returns null for an unknown id — what the route turns into a 404', async () => {
     assert.equal(await store.getProtocolDetail(id('does-not-exist')), null);
   });

--- a/db/src/store.test.ts
+++ b/db/src/store.test.ts
@@ -23,9 +23,11 @@ import {
   toHistoryEntry,
   toLeaderboardEntry,
   toProtocolDetail,
+  toRunHealthEntry,
   type HistoryRow,
   type LeaderboardRow,
   type ProtocolDetailRow,
+  type RunHealthRow,
 } from './store.ts';
 import type { RiskFactorMap } from '@stenion/core';
 
@@ -531,5 +533,83 @@ describe('the deployment label on both public responses', () => {
     );
     assert.equal(detail.safetyScore, null);
     assert.deepEqual(detail.deployedOn, { host: 'Blend', label: 'Blend V2 pool' });
+  });
+});
+
+describe('toRunHealthEntry — the two timestamps GET /api/v1/health is built on', () => {
+  // `last_successful_run_at` and `last_run_at` are separate columns because the
+  // difference between them is the whole signal: a fresh last run beside a stale
+  // last SUCCESS is one broken adapter, and both stale together is the cron not
+  // arriving. Collapsing them would erase the distinction an operator needs.
+
+  const healthRow = (over: Partial<RunHealthRow> = {}): RunHealthRow => ({
+    id: 'blend',
+    last_successful_run_at: RUN_AT,
+    last_run_at: RUN_AT,
+    last_run_status: 'ok',
+    ...over,
+  });
+
+  it('maps a healthy protocol, coercing timestamptz to ISO strings', () => {
+    assert.deepEqual(toRunHealthEntry(healthRow()), {
+      id: 'blend',
+      lastSuccessfulRunAt: '2026-08-16T11:25:02.000Z',
+      lastRunAt: '2026-08-16T11:25:02.000Z',
+      lastRunStatus: 'ok',
+    });
+  });
+
+  it('keeps the last successful run visible when the newest run failed', () => {
+    // The failing-adapter case. The success timestamp must NOT advance to the
+    // failed run's — staleness is measured from it, and moving it would report a
+    // protocol that fails every cycle as permanently fresh.
+    const later = new Date('2026-08-16T11:30:02.000Z');
+    const entry = toRunHealthEntry(healthRow({ last_run_at: later, last_run_status: 'failed' }));
+    assert.equal(entry.lastSuccessfulRunAt, '2026-08-16T11:25:02.000Z');
+    assert.equal(entry.lastRunAt, '2026-08-16T11:30:02.000Z');
+    assert.equal(entry.lastRunStatus, 'failed');
+  });
+
+  it('maps a protocol that has never succeeded to nulls, not to an epoch', () => {
+    const entry = toRunHealthEntry(
+      healthRow({ last_successful_run_at: null, last_run_at: null, last_run_status: null }),
+    );
+    assert.equal(entry.lastSuccessfulRunAt, null);
+    assert.equal(entry.lastRunAt, null);
+    assert.equal(entry.lastRunStatus, null);
+  });
+
+  it('reports a protocol that has only ever failed', () => {
+    // Runs exist, none of them ok: the indexer is reaching this protocol and
+    // getting nothing usable. Distinct from the never-ran case above, and the
+    // health policy has to be able to tell them apart.
+    const entry = toRunHealthEntry(
+      healthRow({ last_successful_run_at: null, last_run_status: 'failed' }),
+    );
+    assert.equal(entry.lastSuccessfulRunAt, null);
+    assert.equal(entry.lastRunAt, '2026-08-16T11:25:02.000Z');
+    assert.equal(entry.lastRunStatus, 'failed');
+  });
+
+  it('publishes ok/failed, the same vocabulary as the other routes', () => {
+    // Not `success`/`failure`. One field name carrying two vocabularies across a
+    // single API is a bug a consumer only finds in production.
+    assert.equal(
+      toRunHealthEntry(healthRow({ last_run_status: 'failed' })).lastRunStatus,
+      'failed',
+    );
+    assert.equal(toRunHealthEntry(healthRow({ last_run_status: 'ok' })).lastRunStatus, 'ok');
+  });
+
+  it('carries no score, factors, or error text', () => {
+    // A freshness probe must not be able to fail because a score was malformed,
+    // and it should not republish an adapter's error string on an unauthenticated
+    // endpoint. The row type is the enforcement; this pins the published keys.
+    assert.deepEqual(Object.keys(toRunHealthEntry(healthRow())).sort(), [
+      'id',
+      'lastRunAt',
+      'lastRunStatus',
+      'lastSuccessfulRunAt',
+    ]);
   });
 });

--- a/db/src/store.ts
+++ b/db/src/store.ts
@@ -155,6 +155,36 @@ export interface RecentRun {
   runAt: string;
 }
 
+/**
+ * One protocol's run freshness, for `GET /api/v1/health`.
+ *
+ * Deliberately the narrowest row in this file: no score, no factors, no error
+ * text. A health probe answers "is the pipeline producing data", and the answer
+ * must not depend on reading a score — an endpoint that has to pull the factor
+ * jsonb to tell you the indexer is alive is one more thing that can be slow or
+ * broken while the thing it reports on is fine.
+ *
+ * The two timestamps are NOT redundant, and the difference between them is the
+ * whole point of the endpoint:
+ *
+ *   `lastSuccessfulRunAt` — the newest **ok** run. This is what staleness is
+ *     measured from, because a failed run produced no data. Null means this
+ *     protocol has never scored successfully; that is never-current, not
+ *     "unknown", and the health policy treats it as such.
+ *   `lastRunAt`/`lastRunStatus` — the newest run of **any** status. These say
+ *     whether the indexer is still *reaching* this protocol at all. A fresh
+ *     `lastRunAt` with a stale `lastSuccessfulRunAt` is a broken adapter (the
+ *     cron is firing, the scoring is failing); both stale together is the cron
+ *     itself not arriving. Flattening them into one field would erase exactly
+ *     the distinction an operator needs to know where to look.
+ */
+export interface RunHealthEntry {
+  id: string;
+  lastSuccessfulRunAt: string | null;
+  lastRunAt: string | null;
+  lastRunStatus: 'ok' | 'failed' | null;
+}
+
 export interface Store {
   /**
    * Insert-or-update the protocol row from adapter metadata. Idempotent.
@@ -178,6 +208,16 @@ export interface Store {
    * — and an empty array must read as "no failures", never as "never succeeded".
    */
   listRecentRuns(protocolId: string, limit: number): Promise<RecentRun[]>;
+  /**
+   * Every protocol's last successful run, last run, and last run status — one
+   * row per protocol, one query. Backs `GET /api/v1/health`.
+   *
+   * Ordered by id, NOT by anything score-derived. Health carries no ranking:
+   * alphabetical is the one ordering that asserts nothing about which protocol
+   * is doing better, which is correct for a list whose entries are only ever
+   * "current" or "not".
+   */
+  listRunHealth(): Promise<RunHealthEntry[]>;
 }
 
 /**
@@ -330,6 +370,32 @@ export function toLeaderboardEntry(row: LeaderboardRow): LeaderboardEntry {
     deployedOn: toDeployedOn(row.deployment_host, row.deployment_label),
     safetyScore: toNumber(row.safety_score),
     computedAt: toIso(row.computed_at),
+    lastRunAt: toIso(row.last_run_at),
+    lastRunStatus: row.last_run_status,
+  };
+}
+
+/** A `protocols` row joined with its run-freshness timestamps, as pg returns it. */
+export interface RunHealthRow {
+  id: string;
+  last_successful_run_at: Date | null;
+  last_run_at: Date | null;
+  last_run_status: 'ok' | 'failed' | null;
+}
+
+/**
+ * One run-health row → one `RunHealthEntry`.
+ *
+ * Timestamps only, and deliberately no derived staleness. How old "too old" is
+ * belongs to the request that asks, not to the row: it is a function of the
+ * clock at read time and of a configurable threshold, and storing or
+ * precomputing it would bake a decision into data that is only true for one
+ * instant. See dashboard/app/api/_health.ts for the policy that consumes this.
+ */
+export function toRunHealthEntry(row: RunHealthRow): RunHealthEntry {
+  return {
+    id: row.id,
+    lastSuccessfulRunAt: toIso(row.last_successful_run_at),
     lastRunAt: toIso(row.last_run_at),
     lastRunStatus: row.last_run_status,
   };
@@ -513,6 +579,46 @@ export function createStore(pool: Pool): Store {
         error: row.error,
         runAt: row.run_at.toISOString(),
       }));
+    },
+
+    async listRunHealth() {
+      // The SAME two LATERAL subqueries listProtocolsWithLatestScore uses, and
+      // the same index walk of (protocol_id, run_at DESC) — the `ok` side just
+      // selects run_at instead of the score, because health asks *when* the last
+      // good run was, not what it said. That is the entire reason this needed no
+      // schema change: the row that answers it was already one column away.
+      //
+      // ONE QUERY, and it has to stay one. A health endpoint that fans out per
+      // protocol gets slower exactly as more protocols are added, which is to say
+      // it degrades in proportion to how much there is to report on — and a probe
+      // that times out under load is indistinguishable from the outage it exists
+      // to detect.
+      //
+      // Nothing score-derived is selected. No safety_score, no factors jsonb: a
+      // freshness probe must not be able to fail because a score was malformed.
+      const { rows } = await pool.query<RunHealthRow>(
+        `SELECT p.id,
+                ok.run_at AS last_successful_run_at,
+                latest.run_at AS last_run_at, latest.status AS last_run_status
+           FROM protocols p
+           LEFT JOIN LATERAL (
+             SELECT run_at
+               FROM risk_scores
+              WHERE protocol_id = p.id AND status = 'ok'
+              ORDER BY run_at DESC
+              LIMIT 1
+           ) ok ON true
+           LEFT JOIN LATERAL (
+             SELECT run_at, status
+               FROM risk_scores
+              WHERE protocol_id = p.id
+              ORDER BY run_at DESC
+              LIMIT 1
+           ) latest ON true
+          ORDER BY p.id`,
+      );
+
+      return rows.map(toRunHealthEntry);
     },
   };
 }

--- a/indexer/src/cycle.test.ts
+++ b/indexer/src/cycle.test.ts
@@ -56,6 +56,11 @@ function fakeStore(
     async getProtocolDetail() {
       return null;
     },
+    // Health reads nothing this fake models — the cycle never calls it. Present
+    // only to satisfy the Store interface.
+    async listRunHealth() {
+      return [];
+    },
     async listRecentRuns(protocolId, limit) {
       if (opts.failReads) throw new Error('connection terminated unexpectedly');
       return (history[protocolId] ?? []).slice(0, limit);


### PR DESCRIPTION
# Add `GET /api/v1/health` — a machine-readable freshness signal for the indexer

Closes #17 

## Why

Scoring silently stopping is the worst failure mode this system has, and it is worst precisely
because **nothing goes red**. The site keeps serving last-known scores, every page renders, no route
500s, and the numbers quietly age. Before this there were two ways to notice: query Neon by hand, or
eyeball a timestamp in the UI and compare it against a clock.

The indexer's existing failure webhook covers a different case. It fires when an adapter fails
repeatedly — and it **cannot fire at all if the cron stops arriving**, because nothing runs to
notice. This is the outside-in check that catches that.

## What was found before implementing

**No schema change was needed.** `listProtocolsWithLatestScore` already runs exactly the query this
needs — two `LEFT JOIN LATERAL` subqueries over the existing `(protocol_id, run_at DESC)` index, one
for the latest `ok` run and one for the latest run of any status. The only thing missing was that the
`ok` lateral selected `safety_score, computed_at` but not `run_at`. `lastSuccessfulRunAt` is one
extra column in a subquery that already existed.

Also confirmed: **success and failure are already distinguishable per protocol**, not inferred from
staleness. `risk_scores.status` is `'ok' | 'failed'` with a CHECK constraint, and `cycle.ts` writes a
`failed` row with the error message rather than leaving a gap.

Rather than widening the leaderboard method, this adds a dedicated narrow `Store.listRunHealth()` —
same reasoning the store already applies to `listRecentRuns` being narrower than `HistoryEntry`. It
selects **no** score columns and **no** `factors` jsonb, so a freshness probe cannot fail because a
score was malformed, and no adapter error text is republished on an unauthenticated endpoint.

## The design question: three states, not a boolean

"Unhealthy" conflates two problems with different owners and different first moves — one adapter
failing (a code bug in one file) versus nothing succeeding anywhere (the pipeline is down). A single
flag forces an operator to open the body to find out which, which is what having a status is
supposed to avoid.

| `status`   | Meaning                                                              | HTTP  |
| ---------- | -------------------------------------------------------------------- | ----- |
| `healthy`  | Every protocol scored successfully within the threshold.             | `200` |
| `degraded` | Some current, some not — or all stale but inside the down window.    | `503` |
| `down`     | Nothing current anywhere, past the down window. The cron looks dead.  | `503` |

Both non-healthy states answer **`503`**, so an uptime monitor catches either without parsing the
body; the label is for the human who opens it afterwards. `503` rather than `500` because nothing
errored — the route queried successfully and is reporting a pipeline that is behind. A genuine `500`
on this route means we could not find out, and keeping them separate is what lets a monitor tell
"the indexer is stopped" from "the health check is broken".

## The exact thresholds, and why

| Setting                          | Default | Reasoning                                                     |
| -------------------------------- | ------- | ------------------------------------------------------------- |
| `STENION_HEALTH_STALE_MINUTES`   | **30**  | Six missed cycles at the ~5-minute cadence.                    |
| `STENION_HEALTH_DOWN_MULTIPLIER` | **2**   | 60 min with not one successful run anywhere before `down`.     |

**Why 30 and not a round guess.** It is sized against a number that already exists in this repo.
`STENION_ALERT_THRESHOLD` is 4 consecutive cycles (~20 minutes), and its stated reasoning is that "a
score 20 minutes stale is not an emergency — false pages are how people learn to ignore alerts". A
`503` an uptime monitor consumes is a **louder** signal than that webhook, so it must sit at a
**higher** bar. 30 > 20 gives the intended escalation order: the webhook mentions it first, and only
if the problem is still there ten minutes later does the monitor go red. There is a test asserting
this ordering, so lowering it below 20 fails CI rather than silently inverting the escalation.

The floor is set by the cadence: under ~10 minutes, one slow cycle, a Vercel cold start, or a single
cron-job.org misfire would read as an outage.

**Why a second, longer window for `down` instead of calling "everything stale at once" down
immediately.** That was the tempting simplification and I think it is wrong here. Every adapter
shares Soroban RPC and Horizon, so a broad upstream outage takes them all out together **while our
own infrastructure is entirely fine** — calling that "the cron is dead" sends an operator to the
wrong place. And with three targets today (one adapter serving several), "all of them" is a small
sample; with a single protocol listed, "all stale" and "one adapter broken" are the same
observation. Doubling the window costs nothing operationally, because `degraded` is **already**
`503` and a monitor has already fired. All the extra 30 minutes buys is the confidence to name which
thing broke, which is the only thing the label is for.

The down window is measured from the **freshest** success across the registry — the most generous
reading available, so the endpoint can never report worse than the truth.

## Two deliberate deviations from the issue

**1. `lastRunStatus` is `ok`/`failed`, not `success`/`failure`.** The issue's example used the
latter. The same underlying column is published as `ok`/`failed` on `/v1/protocols` and
`/v1/protocol/:id`, and one field name carrying two vocabularies across a single API is a bug a
consumer only finds in production. The issue said to adjust field names to match existing
conventions; this applies that to the values too.

**2. A fresh failure alone is not unhealthy.** The issue described `degraded` as "at least one
protocol is stale **or failing**". As implemented, a protocol whose newest run failed but whose
newest *success* is four minutes old reports `healthy`.

That is deliberate. The indexer already retries 3 times before recording a failure at all, but it is
still one cycle, and the data being served is current — turning red there pages someone about a blip
while the numbers are fine. Repeated failure is **not** missed: an adapter that keeps failing stops
producing successful runs and crosses the threshold on its own within 30 minutes. Sustained failure
and staleness are the same event seen at different times, so staleness alone catches it with the
transient case filtered out for free. A consumer who does want to act on any single failed cycle
reads `lastRunStatus`, which is why it is still published per protocol.

## Staleness is measured from the last *successful* run

The load-bearing detail. A failed run produced no score, so measuring from `lastRunAt` would let an
adapter that fails reliably every five minutes report as **perfectly fresh forever** — the exact
inversion of what this endpoint is for.

Both timestamps are published, because read together they say *where* the problem is:

| `lastRunAt` | `lastSuccessfulRunAt` | Meaning                                                  |
| ----------- | --------------------- | -------------------------------------------------------- |
| fresh       | fresh                 | Working.                                                  |
| fresh       | stale                 | Cron is arriving; this adapter is failing. **Isolated.**  |
| stale       | stale                 | Cron is not arriving. **Infrastructure.**                 |
| `null`      | `null`                | Registered but never indexed.                             |

## Not cached — the one place this departs from the other `/v1` routes

`Cache-Control: no-store`. `_cache.ts` works for the other routes because the thing a cache could
hide changes only when a run lands, so expiring before the next run closes the hole. Health does not
behave that way: staleness advances with the **wall clock**, so a body built at 29 minutes stale and
cached for even 45 seconds is still being served, saying `healthy` with a `200`, after the true
answer has become `degraded` with a `503`. The window is small; this is the endpoint whose entire
purpose is to be believed about freshness.

The `503`s must not be cached either, for a stronger reason: the CDN cache key is the URL, so a
cached `503` would go on being served to everyone after the pipeline recovered — turning a resolved
incident into an ongoing one.

Measured cost, warm, from a dev machine: **0.4–1.1s for `listRunHealth` vs 1.1–1.2s for the
leaderboard query**, both dominated by network round trip rather than by the query. The uncached
route is no more expensive per request than the cached one. It is rate limited like everything else.

## Known caveat, measured rather than assumed

A **cold Neon** (scaled to zero) took ~20s to answer the first query. Vercel's default route timeout
is 10s, so a probe landing on a cold database returns a platform `504` rather than this route's own
`503`. Left alone deliberately: Neon only goes cold when nothing has touched it for a long while,
which on this deployment means the indexer has stopped — precisely the case where the verdict is
"unhealthy" regardless. A monitor treats `504` and `503` identically, so the answer survives; only
the body is lost, and raising `maxDuration` to buy it back would make every healthy probe wait
longer.

## Acceptance criteria

- [x] Per-protocol last-successful-run time, last run status, staleness — machine-readable
- [x] Overall status from a configurable threshold, not hardcoded (`STENION_HEALTH_STALE_MINUTES`)
- [x] Non-200 when overall state is unhealthy (`503` for both `degraded` and `down`)
- [x] Documented in `README.md` and `ARCHITECTURE.md` alongside the other endpoints (plus `API.md`,
      `.env.example`, `ROADMAP.md`, and the route list in `CLAUDE.md`)
- [x] Single query — no per-protocol fan-out

## Tests

33 new cases in `dashboard/app/api/_health.test.ts` (policy), 6 in `db/src/store.test.ts` (row
mapping), 3 in `db/src/store.integration.test.ts` (the SQL, gated on `STENION_TEST_DATABASE_URL`).
Full suite: **457 passing, 0 failing.** Lint, typecheck, and `next build` all clean.

These matter more than usual here: `risk_scores` has never held a `failed` row in production, so
`degraded` and `down` have never been produced by real data — and by construction never will be
until the day they matter. A wrong threshold or an inverted comparison shows up as an endpoint that
answers `healthy` through an outage, which is worse than not having it at all: it converts "nobody
was watching" into "the monitor said it was fine".

Covered at minimum, per the issue: all-healthy → `200`; one-protocol-stale → `degraded` + non-200;
all-stale → `down` + non-200. Plus both threshold boundaries, the never-ran case, the empty
registry, clock skew, and malformed env values.

## Follow-up

`API.md`'s `healthy` example was captured from the route's code path against the live production
database (2026-08-22T18:29Z), before the endpoint had a public URL. **Recapture it over HTTP after
promotion.** The `degraded` example is explicitly marked as constructed rather than captured — that
state has never occurred in production and cannot be observed until it does.
