### PR TITLE
declare each category's factor weights once, not ten times across two…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,20 @@ and must never reimplement it, or two protocols end up on two rulebooks) and `fr
 with `STALE_CEILING_SECONDS`. Per-protocol _input reading_ stays in the adapters; nothing in this
 file reaches for chain data.
 
+`scoreFactors()` is generic over the factor map it is handed rather than typed to lending's five
+keys. The weighted mean reads a `value` and a `weight` and nothing else, so it is genuinely
+category-agnostic; typing it to one category's key set would have left the next category with a
+copy of it to keep in sync. There is deliberately no per-category variant of the function.
+
+**`core/src/weights.ts`** holds `CATEGORY_FACTORS` — which factors each `ProtocolCategory` scores,
+what each is weighted, and its label — keyed the same way `METHODOLOGY_VERSIONS` and
+`CATEGORY_OPERATIONS` are. Weights used to be `const weight = 0.25` literals inside each adapter's
+factor methods, ten of them across the two lending adapters; a drift between two copies would have
+produced two plausible scores from two different weightings and failed nothing. Both adapters now
+read `LENDING_FACTORS`, `core/src/scoring.test.ts` pins that declaration against METHODOLOGY.md's
+published weight table, and both adapter suites pin themselves against the declaration — so the
+chain runs adapter → core → the public rulebook with no hand-written copy in it.
+
 **`@stenion/adapters`** — one file per protocol, each a class implementing `Adapter`. An adapter
 reads a protocol's on-chain state (Soroban RPC + Horizon), reduces it into the five `*Safety`
 factors using the formulas in `METHODOLOGY.md`, and produces a weighted `safetyScore`. Currently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,10 @@ These override any default behavior and are enforced in code and review:
 - **Code and `METHODOLOGY.md` are not allowed to drift.** Any change to a formula/threshold/weight
   changes both together, at the same review bar. Shared rulebook logic that two adapters would
   otherwise duplicate lives in [`core/src/scoring.ts`](core/src/scoring.ts), so it can't drift
-  between them.
+  between them. **`METHODOLOGY.md` is organized per category** — each `ProtocolCategory` owns one
+  `##` section holding its factor list, weight table, worked example and version changelog, and
+  `core/src/scoring.test.ts` parses a named category's section rather than the whole file. Adding a
+  category means adding that section; a category without one is a score with no published rules.
 - **A scoring change that makes old scores non-comparable bumps that category's
   `METHODOLOGY_VERSIONS` entry** (`core/src/category.ts`), stamped onto every run by the indexer
   alongside `risk_scores.category` — counters are per category and each starts at 1, so the pair
@@ -120,6 +123,15 @@ These override any default behavior and are enforced in code and review:
   exception — it imports `./retry.ts` / `./alerts.ts` with explicit extensions, and
   `indexer/tsconfig.build.json` adds `rewriteRelativeImportExtensions` so tsc emits `.js`. Prefer
   the leaf shape; reach for the flag only when a tested module genuinely needs siblings.
+- **A weight is never a literal in an adapter.** Which factors a category scores, what each is
+  weighted, and what it is called are declared once in
+  [`core/src/weights.ts`](core/src/weights.ts) (`CATEGORY_FACTORS`, keyed by `ProtocolCategory`
+  like `METHODOLOGY_VERSIONS` and `CATEGORY_OPERATIONS`); adapters read
+  `LENDING_FACTORS.<factor>.weight`. Two adapters holding their own copies of the same weight can
+  drift into two rulebooks while both still produce plausible scores — the failure the shared
+  `scoreFactors` exists to prevent, applied to the numbers it averages. `scoreFactors` is generic
+  over the factor map for the same reason: the weighted mean is category-agnostic, so there must
+  never be a per-category variant of it.
 - **One adapter may serve several markets; a market never gets its own adapter.** `BlendAdapter`
   takes a `BlendPool` (slug, name, pool contract, mark, links, `deployedOn`) and the indexer
   iterates `BLEND_POOLS` — every Blend market runs the same wasm, so a second pool is a config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,11 +213,11 @@ Every adapter must populate the same fixed five factors from `RiskFactorType`
 
 ```ts
 riskFactors: {
-  collateralSafety,    // collateral concentration (diversification)  — weight 0.20
-  oracleSafety,        // price freshness + manipulation resistance   — weight 0.25
-  adminKeySafety,      // admin signer structure + activity            — weight 0.20
-  liquiditySafety,     // free-liquidity depth (withdrawal cushion)    — weight 0.15
-  utilizationSafety,   // headroom below the configured utilization cap — weight 0.20
+  collateralSafety,    // collateral concentration (diversification)
+  oracleSafety,        // price freshness + manipulation resistance
+  adminKeySafety,      // admin signer structure + activity
+  liquiditySafety,     // free-liquidity depth (withdrawal cushion)
+  utilizationSafety,   // headroom below the configured utilization cap
 }
 ```
 
@@ -230,6 +230,16 @@ Conventions you must not break:
 - **Every key must be present.** Use `null` (not omission) for a factor that genuinely doesn't
   apply to your protocol, so the dashboard renders "N/A" instead of silently dropping it. The
   `score()` weighted mean renormalizes over the non-null factors.
+- **Take each factor's `weight` from `CATEGORY_FACTORS`, never a literal.** Import
+  `LENDING_FACTORS` from `@stenion/core` and write
+  `const weight = LENDING_FACTORS.oracleSafety.weight;`. A weight is part of the shared rulebook,
+  not something an adapter picks: the numbers used to be spelled out inside each adapter, and two
+  copies that drift produce two plausible scores from two different weightings while failing
+  nothing. The declarations live in [`core/src/weights.ts`](core/src/weights.ts), keyed by
+  category, and `core/src/scoring.test.ts` pins them against `METHODOLOGY.md`'s published weight
+  table. Your adapter's suite should assert it carries what its category declares — see the
+  `the factor map itself` block in either lending suite — rather than restating the numbers, which
+  would just be another copy.
 - **Each factor carries a `detail` string** — a short, human-readable explanation of what drove the
   value (e.g. "top reserve holds 95% of supplied value"). This is what the dashboard shows and what
   makes the number auditable. Write a real one.
@@ -243,8 +253,11 @@ Conventions you must not break:
   label through `shortenAddressesIn` before it lands in a detail string; it shortens the address and
   keeps the qualifier around it, which is real information.
 
-**How** a factor is computed can differ per protocol; the names, scale, and thresholds do not. New
-factors are added to `@stenion/core` for everyone at once — never invented per-adapter.
+**How** a factor is computed can differ per protocol; the names, scale, weights, and thresholds do
+not — **within a category**. New factors are added to `@stenion/core` for everyone in that category
+at once, never invented per-adapter. The five above are lending's set; a different category
+declares its own in `CATEGORY_FACTORS` and publishes it in its own `METHODOLOGY.md` section, and
+that is the only place a rule is allowed to differ.
 
 **`score()` delegates to `@stenion/core` — do not reimplement the weighted mean.** Your adapter's
 `score()` is one line:

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -7,10 +7,12 @@ directly from the shipped code (currently [`adapters/blend.ts`](adapters/blend.t
 [`adapters/kinetic.ts`](adapters/kinetic.ts)); this file is not a summary of intent, it is
 the rulebook the adapters must implement.
 
-**One formula, per-protocol data sources.** Every factor's formula, scale, and thresholds
-are fixed here and identical across protocols — and across _markets_: the three Blend pools
-Stenion scores run one adapter and one rulebook, differing only in the pool each reads. What legitimately differs per adapter is only
-_where the raw inputs are read on-chain_ — e.g. Blend reads a per-reserve `max_util` cap,
+**One formula per category, per-protocol data sources.** Every factor's formula, scale, and
+thresholds are fixed here and identical across every protocol in a category — and across
+_markets_: the three Blend pools Stenion scores run one adapter and one rulebook, differing only
+in the pool each reads. Each category owns a section below, holding its own factor list, weight
+table, worked example and version changelog; **lending** is the only one today. What legitimately
+differs per adapter is only _where the raw inputs are read on-chain_ — e.g. Blend reads a per-reserve `max_util` cap,
 while Kinetic (K2), being Aave-V3-style, has no such cap and instead anchors the same
 utilization formula to its own `OPTIMAL_UTILIZATION_RATE` (see §5). The _anchoring pattern_
 ("grade against the protocol's own on-chain parameter") is the invariant; the specific
@@ -23,14 +25,26 @@ If the code and this document ever disagree, that is a bug — open an issue (se
 
 ## Current version
 
-**Methodology v1** — the rulebook described by this document, in full, including `oracleSafety`
-scoring both price freshness and manipulation resistance (§2), the minimum-size filter §4
-and §5 select reserves through ([The minimum-size filter](#the-minimum-size-filter)), and the
+Versions are **per category**, on independent counters that each start at 1, so a version number
+alone does not identify a rulebook — the category and the number together do. One row per
+category, and the changelog behind each lives in that category's own section:
+
+| Category  | Current version | Rulebook and changelog |
+| --------- | --------------- | ---------------------- |
+| `lending` | 1               | [Lending](#lending)    |
+
+**Lending, methodology v1** — the rulebook described in the [Lending](#lending) section, in full,
+including `oracleSafety` scoring both price freshness and manipulation resistance (§2), the
+minimum-size filter §4 and §5 select reserves through
+([The minimum-size filter](#the-minimum-size-filter)), and the
 [market-size floor](#the-market-size-floor) that decides whether a market is scorable at all.
 The floor is a precondition rather than a formula — it moves no number and did not bump this
 version.
 
-**Versioning begins here.** `methodology_version = 1` is the only version this rulebook
+The rest of this section — what bumps a version, and what a boundary means for a stored score —
+is policy that applies to **every** category, not just lending.
+
+**Versioning begins here.** `methodology_version = 1` is the only version lending's rulebook
 defines, and the only one any stored row will carry. A version 2 was briefly live in the code
 — stamped onto runs between 2026-08-14 11:25 and 2026-08-18 11:30 UTC, before the rulebook was
 flattened back to v1 — and that history is discarded rather than migrated, for the same reason
@@ -95,9 +109,15 @@ one, including us, can recompute an old row under new rules.
 
 ## Ground rules (non-negotiable)
 
-1. **The same formula applies to every protocol, with no exceptions.** A factor's formula
-   and its thresholds are fixed here, in one shared place. They do not vary per protocol,
-   per adapter, or per anything else.
+1. **The same formula applies to every protocol in a category, with no exceptions.** A
+   factor's formula, its weight, and its thresholds are fixed in that category's section
+   below, in one shared place. They do not vary per protocol, per adapter, or per anything
+   else _within_ the category. **A category boundary is the one and only place a rule may
+   differ** — and it differs because the factor sets differ, not because a protocol asked:
+   `utilizationSafety` weighted 0.20 says nothing about an AMM with no borrow cap. That is a
+   different rulebook, published in full under its own heading and versioned on its own
+   counter, never lending's rules bent to fit. Two protocols in the same category are always
+   graded by the same rules.
 2. **Payment never changes a threshold or a formula.** Protocols can pay for visibility,
    speed, or private tooling — never for a better number. A paid tier cannot move a
    threshold, reweight a factor, or alter a curve. The _only_ thing that changes a
@@ -119,13 +139,21 @@ one, including us, can recompute an old row under new rules.
 - **Every factor is on the same scale: 0–100, higher = safer.** Factor names end in
   `*Safety` so a name never disagrees with its number — a `collateralSafety` of 70 means
   well-diversified (safe), not "70% concentrated."
-- The overall score is a **weighted mean of the five factors**, renormalized over whichever
-  factors are non-null (so a genuinely inapplicable factor doesn't drag the score toward
-  zero rather than being excluded):
+- The overall score is a **weighted mean of the category's factors**, renormalized over
+  whichever factors are non-null (so a genuinely inapplicable factor doesn't drag the score
+  toward zero rather than being excluded):
 
   ```
   safetyScore = round( Σ(factor.value × factor.weight) / Σ(factor.weight) )
   ```
+
+**This arithmetic is shared; the factors it averages are not.** The formula above is
+category-agnostic — it reads a value and a weight and nothing else — and it is implemented once,
+in `scoreFactors` ([`core/src/scoring.ts`](core/src/scoring.ts)), which every adapter of every
+category calls. **Which** factors exist and **what each is weighted** is per category: declared
+once in `CATEGORY_FACTORS` ([`core/src/weights.ts`](core/src/weights.ts)) and published in that
+category's own section below. So the weight table and the factor list live under
+[Lending](#lending), not here — a second category would bring its own, not edit lending's.
 
 A factor may publish a **`components`** breakdown — the sub-signals behind its value.
 Components with a numeric `value` are what the factor was computed from; components with
@@ -139,14 +167,31 @@ multiplier, and not an input to `safetyScore` — see
 [Operational state is published, never scored](#operational-state-is-published-never-scored) for
 why, and for why that is a decision rather than an omission.
 
-### Methodology versions
+---
+
+## Lending
+
+Everything from here to
+[Operational state](#operational-state-is-published-never-scored) is **lending's rulebook and
+lending's alone** — its version changelog, its factor weights, its worked example, and the five
+factors themselves. It is the only category Stenion publishes a rulebook for today
+(`PROTOCOL_CATEGORIES` in [`core/src/category.ts`](core/src/category.ts)), and this section is
+the shape a second one would take: its own heading, its own changelog, its own weight table, its
+own factor list. Nothing above this line is lending-specific; nothing below it may be assumed to
+hold for a category that isn't lending.
+
+**Which protocols are scored under it:** every market on the registry today — the three Blend
+pools ([`adapters/blend.ts`](adapters/blend.ts)) and Kinetic/K2
+([`adapters/kinetic.ts`](adapters/kinetic.ts)). Ground rule 1 binds all of them to what follows.
+
+### Version changelog
 
 Every scored run is stamped with the rulebook version that produced it
 (`risk_scores.methodology_version`, from the `lending` entry in `METHODOLOGY_VERSIONS` in
 [`core/src/category.ts`](core/src/category.ts)), and it is surfaced on the API's protocol detail
-and on each history point. Versions are per category and counters are independent, so the changelog
-below is **lending's**; another category's v1 is a different rulebook, not an earlier one. The
-changelog:
+and on each history point. Versions are per category and counters are independent, so this
+changelog is **lending's**; another category's v1 is a different rulebook, not an earlier one.
+Each category gets exactly one such table, in its own section. The changelog:
 
 | Version | Effective | Change                                                                                                                                                                                                                 |
 | ------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -199,6 +244,11 @@ appearing as an unexplained step in a chart.
 
 ### Factor weights
 
+Lending's weights, and lending's only. This table is the published face of
+`CATEGORY_FACTORS.lending` in [`core/src/weights.ts`](core/src/weights.ts), which is where the
+adapters read them from — neither adapter contains a weight of its own, and
+`core/src/scoring.test.ts` parses this table and fails if the two disagree in either direction.
+
 | Factor              | Weight   |
 | ------------------- | -------- |
 | `oracleSafety`      | 0.25     |
@@ -208,7 +258,7 @@ appearing as an unexplained step in a chart.
 | `liquiditySafety`   | 0.15     |
 | **Total**           | **1.00** |
 
-**Worked example (live Blend Fixed V2 pool, 2026-08-14, methodology v1):**
+**Worked example (live Blend Fixed V2 pool, 2026-08-14, lending methodology v1):**
 `70×0.20 + 100×0.25 + 40×0.20 + 22×0.15 + 14×0.20 = 53.1 → 53`.
 
 > **Weights are an unvalidated judgment call, not an external fact.** `oracleSafety` carries the most
@@ -224,7 +274,7 @@ appearing as an unexplained step in a chart.
 
 ---
 
-## The five factors
+### The five lending factors
 
 For each factor: the exact raw on-chain data that feeds it, the exact formula, and why the
 thresholds are what they are (anchored to an external/on-chain value where one exists,
@@ -245,7 +295,7 @@ borrowed = d_supply × d_rate / (SCALAR_12 × 10^assetDecimals)
 
 ---
 
-### 1. `collateralSafety` — collateral concentration (weight 0.20)
+#### 1. `collateralSafety` — collateral concentration (weight 0.20)
 
 **What it measures:** how spread out the pool's supplied value is across its reserves. A
 pool whose value sits in one asset is far more exposed to a single de-peg or liquidation
@@ -285,7 +335,7 @@ many reserves it has, not against an arbitrary constant.
 
 ---
 
-### 2. `oracleSafety` — price trustworthiness: freshness _and_ manipulation resistance (weight 0.25)
+#### 2. `oracleSafety` — price trustworthiness: freshness _and_ manipulation resistance (weight 0.25)
 
 > **Why this factor is not just price age.** An age-only oracle factor scores a fresh but
 > manipulated price 100 — which is precisely the configuration behind the February 2026
@@ -323,7 +373,7 @@ aggregator publish round, so its reserves carry identical ages and **always** ti
 Naming one of them would make an iteration-order artifact read as a diagnosis, and a reserve
 name that is really a tie-break is worse than no name at all.
 
-#### 2a. `priceFreshness` — how stale the worst price is
+##### 2a. `priceFreshness` — how stale the worst price is
 
 **Raw on-chain data (Soroban RPC):** per reserve, the price's publish `timestamp` from
 the method the protocol's own pool calls; `fetchedAt` is the adapter's read time;
@@ -359,7 +409,7 @@ numbers are K2's, and the binding one is the one that governs.
 > threshold here. It lives in one place, `STALE_CEILING_SECONDS` in
 > [`core/src/scoring.ts`](core/src/scoring.ts).
 
-#### 2b. `deviationBound` — can a single update move the price arbitrarily far?
+##### 2b. `deviationBound` — can a single update move the price arbitrarily far?
 
 **Binary, not a curve:**
 
@@ -397,7 +447,7 @@ disclosed. (Whether such a peg _holds_ is a real risk — but it is a collateral
 question, not an oracle-robustness one, and inventing a number for it here would be the
 kind of fabrication ground rule 4 forbids.)
 
-#### 2c. Per-feed price ages are disclosed, never scored
+##### 2c. Per-feed price ages are disclosed, never scored
 
 `priceFreshness` grades the **worst** reserve, which is the right thing to score but hides the
 **spread** — and on real data the spread is the informative part. A factor value of 0 reads as
@@ -416,7 +466,7 @@ computed from, republished so that the grading can be checked rather than taken 
 published on healthy pools as well as unhealthy ones — a disclosure that appears only where
 trouble is expected gives a reader no baseline to compare against.
 
-#### 2d. Bound tightness is disclosed, never scored
+##### 2d. Bound tightness is disclosed, never scored
 
 The raw bound is published as a **disclosure-only component** (`value: null`) — visible,
 never graded. Grading it would invent comparability the underlying data does not support:
@@ -434,7 +484,7 @@ different quantities, so the intuitive reading that K2's bound is three times ti
 Blend's is unsound. Publishing the numbers side by side without a score is the honest
 treatment.
 
-#### 2e. The oracle-legibility precondition
+##### 2e. The oracle-legibility precondition
 
 Both halves of this factor are anchored to parameters **the pool's own price path
 publishes**: §2a's window comes from `resolution` and `max_age`, §2b's bound from per-asset
@@ -476,7 +526,7 @@ separate reading of a separate contract's semantics. All four answer `decimals()
 `lastprice()`, so §1, §3, §4 and §5 compute normally for them; what is missing is only the
 metadata §2 grades against.
 
-##### Why there is no fallback anchor: SEP-40 does not define one
+###### Why there is no fallback anchor: SEP-40 does not define one
 
 Stated plainly rather than worked around. [SEP-40](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0040.md)
 defines `base, assets, decimals, resolution, price, prices, lastprice` — **no maximum
@@ -500,7 +550,7 @@ And `resolution()` is only present on one of the four at all. Orbit and Forex ex
 hop upstream through their bridge/proxy, which would make the anchor a property of a contract
 the pool does not itself publish; Spectra has no upstream feed to chase.
 
-##### Two of the four price off the ledger clock, so freshness is 100 by construction
+###### Two of the four price off the ledger clock, so freshness is 100 by construction
 
 The sharper problem, and the reason this is a precondition rather than a "weak signal":
 
@@ -519,7 +569,7 @@ The sharper problem, and the reason this is a precondition rather than a "weak s
 A fabricated **100** is worse than a fabricated 0, because 0 at least renders in the danger
 band where a reader discounts it. Ground rule 4 forbids both.
 
-##### What was rejected, and why it must not be re-proposed
+###### What was rejected, and why it must not be re-proposed
 
 - **Make the three calls optional and score `oracleSafety` on what remains.** Rejected: there
   is nothing to score on. Both anchors are gone, `deviationBound` collapses to a constant 0
@@ -590,7 +640,7 @@ same conclusion, as the market-size floor.
 > deviation bound, the pool becomes scorable with **no rule change** — it is a `BLEND_POOLS`
 > entry and a deleted coverage entry, in one PR.
 
-#### What was considered and deliberately rejected
+##### What was considered and deliberately rejected
 
 Recorded so these are not re-proposed as improvements later. Each was investigated against
 the February 2026 YieldBlox incident — the test being whether it would have distinguished
@@ -648,7 +698,7 @@ prices, lastprice, last_timestamp, history_retention_period, …`. Earlier Refle
   retroactively, because the exploited market has since been rebuilt. Tracked as a
   candidate in [`ROADMAP.md`](ROADMAP.md) rather than shipped on intuition.
 
-#### What this factor would have said on 2026-02-22
+##### What this factor would have said on 2026-02-22
 
 Running the shipped adapter against the exploited pool and the healthy one today, same
 rulebook, no special-casing:
@@ -702,7 +752,7 @@ anyway, and on the axis that actually failed.
 
 ---
 
-### 3. `adminKeySafety` — admin signer structure + activity (weight 0.20)
+#### 3. `adminKeySafety` — admin signer structure + activity (weight 0.20)
 
 **What it measures:** how much unilateral, live control a single party has over the pool. A
 lone hot key that can reconfigure the pool is the sharpest centralization risk; multisig
@@ -765,7 +815,7 @@ score.
 
 ---
 
-### 4. `liquiditySafety` — free-liquidity depth (weight 0.15)
+#### 4. `liquiditySafety` — free-liquidity depth (weight 0.15)
 
 **What it measures:** the absolute withdrawal/liquidation cushion — how much value could
 leave before the pool is drained. Distinct from `utilizationSafety`, which measures
@@ -794,7 +844,7 @@ rule 4 forbids. The two are reported with different `detail` strings: "the pool 
 
 ---
 
-### The minimum-size filter
+#### The minimum-size filter
 
 Applies to **`liquiditySafety` (§4) and `utilizationSafety` (§5) only**, identically for every
 protocol.
@@ -912,7 +962,7 @@ anchor.
 
 ---
 
-### The market-size floor
+#### The market-size floor
 
 The [minimum-size filter](#the-minimum-size-filter) one level up. That filter asks whether a
 _reserve_ is big enough for its number to mean anything; this asks the same of a whole
@@ -1024,7 +1074,7 @@ precondition on what gets scored at all, which is additive.
 
 ---
 
-### 5. `utilizationSafety` — headroom below the configured cap (weight 0.20)
+#### 5. `utilizationSafety` — headroom below the configured cap (weight 0.20)
 
 **What it measures:** how close live utilization is to the protocol's own on-chain
 utilization stress line — the point the protocol itself defines as "borrowing should stop

--- a/adapters/blend.test.ts
+++ b/adapters/blend.test.ts
@@ -23,7 +23,7 @@ import {
   oracleNotGradable,
 } from './blend.ts';
 import type { BlendRawData, BlendReserveRaw, OracleGradingReads } from './blend.ts';
-import { OperationalLevel, PoolOperation } from '@stenion/core';
+import { LENDING_FACTORS, OperationalLevel, PoolOperation } from '@stenion/core';
 import type { RiskFactor } from '@stenion/core';
 
 // ---------------------------------------------------------------------------
@@ -433,13 +433,30 @@ describe('the factor map itself', () => {
     }
   });
 
-  it('carries the weights METHODOLOGY.md documents', async () => {
+  it('carries the weights the shared lending rulebook declares', async () => {
+    // PINNED AGAINST THE ONE SHARED SOURCE, NOT AGAINST FIVE LITERALS. This
+    // used to spell the numbers out, which made it a second hand-written copy of
+    // the weight table — it would have passed happily while the adapter and
+    // METHODOLOGY.md disagreed, as long as someone updated both copies of the
+    // literal. Reading `LENDING_FACTORS` instead makes the chain
+    // adapter -> core -> METHODOLOGY.md, with core/src/scoring.test.ts pinning
+    // the last link by parsing the published table. No number in this file.
     const f = await factors(makeRaw());
-    assert.equal(f.collateralSafety!.weight, 0.2);
-    assert.equal(f.oracleSafety!.weight, 0.25);
-    assert.equal(f.adminKeySafety!.weight, 0.2);
-    assert.equal(f.liquiditySafety!.weight, 0.15);
-    assert.equal(f.utilizationSafety!.weight, 0.2);
+
+    assert.deepEqual(
+      Object.keys(f).sort(),
+      Object.keys(LENDING_FACTORS).sort(),
+      'the adapter populates a different factor set than lending declares',
+    );
+
+    for (const [key, decl] of Object.entries(LENDING_FACTORS)) {
+      assert.equal(
+        f[key as keyof typeof f]!.weight,
+        decl.weight,
+        `${key} is weighted ${f[key as keyof typeof f]!.weight} here but ` +
+          `${decl.weight} in CATEGORY_FACTORS.lending`,
+      );
+    }
   });
 });
 

--- a/adapters/blend.ts
+++ b/adapters/blend.ts
@@ -17,6 +17,7 @@ import { rpc } from '@stellar/stellar-sdk';
 // which has no runtime `Adapter` export. Keep type-only names under
 // `import type`.
 import {
+  LENDING_FACTORS,
   PoolOperation,
   RiskFactorType,
   describePriceAges,
@@ -1201,13 +1202,24 @@ export class BlendAdapter implements Adapter<BlendRawData, 'lending'> {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // The five factors.
+  //
+  // Each reads Blend-specific raw state, and each takes its weight from
+  // `LENDING_FACTORS` in @stenion/core rather than from a literal. A weight is
+  // part of the shared rulebook, not a per-adapter choice: with the number
+  // written out here and again in kinetic.ts, a drift between the two would have
+  // produced two plausible scores from two different weightings and failed
+  // nothing. See core/src/weights.ts.
+  // ---------------------------------------------------------------------------
+
   // Concentration of supplied value across reserves, via a normalized HHI.
   // Rationale: a pool whose value sits in one asset is far more exposed to a
   // single de-peg/liquidation cascade than a balanced one. HHI = Σ(share²);
   // for n reserves it ranges [1/n, 1]. We map 1/n → 100 (safest, even split)
   // and 1 → 0 (all in one asset). Pure on-chain supplied USD, no assumptions.
   private collateralSafety(raw: BlendRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.collateralSafety.weight;
     const values = raw.reserves
       .map((r) => suppliedUsd(r, raw.oracleDecimals))
       .filter((v): v is number => v !== null && v > 0);
@@ -1244,7 +1256,7 @@ export class BlendAdapter implements Adapter<BlendRawData, 'lending'> {
   // constraint (the lower of the two) — a bounded stale price and a fresh
   // unbounded price are both untrustworthy, for different reasons.
   private oracleSafety(raw: BlendRawData): RiskFactor {
-    const weight = 0.25;
+    const weight = LENDING_FACTORS.oracleSafety.weight;
 
     // Base assets are the aggregator's unit of account: `lastprice` returns a
     // hardcoded 1.0 at the current ledger time for them, never reading an
@@ -1358,7 +1370,7 @@ export class BlendAdapter implements Adapter<BlendRawData, 'lending'> {
   // an actively-used admin key is a live lever. Contract-governed admins can't
   // be introspected via Horizon, so they get a flagged neutral baseline.
   private adminKeySafety(raw: BlendRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.adminKeySafety.weight;
     const a = raw.admin;
 
     if (a.isContract || a.account === null) {
@@ -1392,7 +1404,7 @@ export class BlendAdapter implements Adapter<BlendRawData, 'lending'> {
   // Reserves below the shared minimum size are excluded before selection — see
   // reserveSizing() and METHODOLOGY.md §4 — and disclosed rather than dropped.
   private liquiditySafety(raw: BlendRawData): RiskFactor {
-    const weight = 0.15;
+    const weight = LENDING_FACTORS.liquiditySafety.weight;
     const sizing = this.reserveSizing(raw);
     const excluded: ExcludedReserve[] = [];
     let worstRatio = 1;
@@ -1446,7 +1458,7 @@ export class BlendAdapter implements Adapter<BlendRawData, 'lending'> {
   // worst reserve wins. util here is computed live (borrowed/supplied), not the
   // config's target field.
   private utilizationSafety(raw: BlendRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.utilizationSafety.weight;
     const sizing = this.reserveSizing(raw);
     const excluded: ExcludedReserve[] = [];
     let worst = 100;

--- a/adapters/kinetic.test.ts
+++ b/adapters/kinetic.test.ts
@@ -16,7 +16,7 @@ import { describe, it } from 'node:test';
 
 import { KineticAdapter, decodeDecimals, decodeReserveFlags } from './kinetic.ts';
 import type { KineticRawData, KineticReserveFlags, KineticReserveRaw } from './kinetic.ts';
-import { OperationalLevel } from '@stenion/core';
+import { LENDING_FACTORS, OperationalLevel } from '@stenion/core';
 import type { RiskFactor } from '@stenion/core';
 
 // ---------------------------------------------------------------------------
@@ -334,6 +334,60 @@ describe('documented gaps — pinned so a change to them is deliberate', () => {
       Object.values(running).map((f) => f?.value),
       'pause state is not scored yet — see ROADMAP.md',
     );
+  });
+});
+
+describe('the factor map itself', () => {
+  // THE MIRROR OF blend.test.ts'S BLOCK OF THE SAME NAME, and it is here because
+  // it was not. Blend's weights had been pinned against the rulebook since the
+  // adapter was written; Kinetic's had never been pinned against anything, so a
+  // typo in one of its five weight literals would have gone out as a published
+  // score with no test between it and production. Both adapters implement one
+  // shared rulebook (METHODOLOGY.md ground rule 1), so both are held to it here,
+  // to the same standard and against the same source.
+
+  it('populates all five factors, each with a real detail string', async () => {
+    const f = await factors(makeRaw());
+    for (const [key, value] of Object.entries(f)) {
+      assert.ok(value !== undefined, `${key} must be present`);
+      assert.ok(value !== null, `${key} should be populated for a normal K2 market`);
+      assert.ok(value.detail.length > 0, `${key} needs a human-readable detail`);
+      assert.ok(value.value >= 0 && value.value <= 100, `${key} out of the 0-100 range`);
+    }
+  });
+
+  it('carries the weights the shared lending rulebook declares', async () => {
+    // Reads `LENDING_FACTORS` rather than spelling the five numbers out, so this
+    // is not a second hand-written copy of the weight table — it is the same
+    // declaration blend.test.ts checks against, and core/src/scoring.test.ts
+    // pins that declaration to METHODOLOGY.md's published table. No number in
+    // this file.
+    const f = await factors(makeRaw());
+
+    assert.deepEqual(
+      Object.keys(f).sort(),
+      Object.keys(LENDING_FACTORS).sort(),
+      'the adapter populates a different factor set than lending declares',
+    );
+
+    for (const [key, decl] of Object.entries(LENDING_FACTORS)) {
+      assert.equal(
+        f[key as keyof typeof f]!.weight,
+        decl.weight,
+        `${key} is weighted ${f[key as keyof typeof f]!.weight} here but ` +
+          `${decl.weight} in CATEGORY_FACTORS.lending`,
+      );
+    }
+  });
+
+  it('weights the same factors Blend does — one rulebook, two adapters', async () => {
+    // The point of a shared declaration, stated as a property rather than left
+    // implicit: if these two ever disagree, one of them has stopped reading the
+    // rulebook. Compared against the declaration rather than against Blend's
+    // adapter so this suite stays runnable on its own.
+    const f = await factors(makeRaw());
+    const total = Object.values(f).reduce((a, v) => a + (v ? v.weight : 0), 0);
+    assert.ok(Math.abs(total - 1) < 1e-9, `the populated weights sum to ${total}, not 1.00`);
   });
 });
 

--- a/adapters/kinetic.ts
+++ b/adapters/kinetic.ts
@@ -14,6 +14,7 @@ import { rpc } from '@stellar/stellar-sdk';
 // type stripping is syntactic, so type-only names left in a value import
 // survive into the running module and fail against core's CommonJS output.
 import {
+  LENDING_FACTORS,
   PoolOperation,
   RiskFactorType,
   describePriceAges,
@@ -839,12 +840,21 @@ export class KineticAdapter implements Adapter<KineticRawData, 'lending'> {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // The five factors.
+  //
+  // Each reads K2-specific raw state, and each takes its weight from
+  // `LENDING_FACTORS` in @stenion/core rather than from a literal — the same
+  // declarations blend.ts reads, so the two adapters cannot come to weight the
+  // same factor differently. See core/src/weights.ts.
+  // ---------------------------------------------------------------------------
+
   // Concentration of supplied value across reserves, via a normalized HHI.
   // Identical formula/anchors to Blend (METHODOLOGY.md §1): HHI = Σ(share²),
   // mapped 1/n → 100 (even split) and 1 → 0 (all in one asset). Pure on-chain
   // supplied USD.
   private collateralSafety(raw: KineticRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.collateralSafety.weight;
     const values = raw.reserves
       .map((r) => suppliedUsd(r, raw.oraclePriceDecimals))
       .filter((v): v is number => v !== null && v > 0);
@@ -881,7 +891,7 @@ export class KineticAdapter implements Adapter<KineticRawData, 'lending'> {
   // (the window inside which K2 itself considers a price current) and `dead` to
   // the tighter of its per-asset max_age and its global staleness threshold.
   private oracleSafety(raw: KineticRawData): RiskFactor {
-    const weight = 0.25;
+    const weight = LENDING_FACTORS.oracleSafety.weight;
     const { maxPriceChangeBps, priceStalenessThreshold, priceCacheTtl } = raw.oracleConfig;
 
     const worstFresh = worstBy(raw.reserves, (r) => {
@@ -978,7 +988,7 @@ export class KineticAdapter implements Adapter<KineticRawData, 'lending'> {
   // K2's admin (PADMIN) is expected to be a governance contract (C…), which
   // Horizon can't introspect → neutral baseline, flagged in the detail.
   private adminKeySafety(raw: KineticRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.adminKeySafety.weight;
     const a = raw.admin;
 
     if (a.isContract || a.account === null) {
@@ -1005,7 +1015,7 @@ export class KineticAdapter implements Adapter<KineticRawData, 'lending'> {
   // reserve. Identical to Blend (METHODOLOGY.md §4): the absolute withdrawal
   // cushion, distinct from utilizationSafety's proximity-to-cap.
   private liquiditySafety(raw: KineticRawData): RiskFactor {
-    const weight = 0.15;
+    const weight = LENDING_FACTORS.liquiditySafety.weight;
     const sizing = this.reserveSizing(raw);
     const excluded: ExcludedReserve[] = [];
     let worstRatio = 1;
@@ -1059,7 +1069,7 @@ export class KineticAdapter implements Adapter<KineticRawData, 'lending'> {
   // protocol's own on-chain utilization parameter — see METHODOLOGY.md §5):
   // headroom = (0.8 − util)/0.8, worst reserve wins.
   private utilizationSafety(raw: KineticRawData): RiskFactor {
-    const weight = 0.2;
+    const weight = LENDING_FACTORS.utilizationSafety.weight;
     const sizing = this.reserveSizing(raw);
     const excluded: ExcludedReserve[] = [];
     let worst = 100;

--- a/core/src/category.test.ts
+++ b/core/src/category.test.ts
@@ -25,6 +25,11 @@ import { describe, it } from 'node:test';
 
 // A VALUE import, deliberately — see the header. Type-only would prove nothing.
 import { METHODOLOGY_VERSIONS, PROTOCOL_CATEGORIES } from './category.ts';
+import type { ProtocolCategory } from './category.ts';
+// For each category's METHODOLOGY.md section heading — the label is declared
+// once, beside the factor set, so the doc and the code cannot disagree about
+// what a category's section is called.
+import { CATEGORY_FACTORS } from './weights.ts';
 
 /** Walk up from the test's cwd to find a repo file, so this works from any package dir. */
 function repoFile(name: string): string {
@@ -36,6 +41,27 @@ function repoFile(name: string): string {
     if (parent === dir) throw new Error(`could not find ${name} walking up from ${process.cwd()}`);
     dir = parent;
   }
+}
+
+/**
+ * One category's slice of METHODOLOGY.md: its `## <Label>` heading down to the
+ * next h2.
+ *
+ * Deliberately duplicated from `scoring.test.ts` rather than shared. A test file
+ * importing another test file makes the helper run as a suite of its own under
+ * `node --test`, and this file already carries its own `repoFile` for the same
+ * reason. If a third copy is ever wanted, that is the point to move all three
+ * into a real module instead.
+ */
+function categorySection(doc: string, category: ProtocolCategory): string {
+  const heading = `## ${CATEGORY_FACTORS[category].label}`;
+  const lines = doc.split('\n');
+  const start = lines.findIndex((l) => l.trimEnd() === heading);
+  assert.ok(start >= 0, `METHODOLOGY.md has no "${heading}" section for category ${category}`);
+  const rest = lines.slice(start + 1);
+  // `^## ` matches an h2 only — an h3 starts `###`, so the space fails to match.
+  const end = rest.findIndex((l) => /^## /.test(l));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
 }
 
 describe('the category registry', () => {
@@ -99,22 +125,35 @@ describe('the category registry', () => {
     assert.equal(METHODOLOGY_VERSIONS.lending, 1);
   });
 
-  it('agrees with the version METHODOLOGY.md publishes for lending', () => {
-    // Code and METHODOLOGY.md are not allowed to drift (CLAUDE.md). The doc's
-    // changelog table has a **1** row for the five-factor model; this asserts the
-    // constant still matches it, reading the doc rather than restating it — the
-    // same approach scoring.test.ts takes, and for the same reason: a test that
-    // hardcodes the doc's number is a third copy to keep in sync.
+  it('agrees with the version METHODOLOGY.md publishes for each category', () => {
+    // Code and METHODOLOGY.md are not allowed to drift (CLAUDE.md). Each
+    // category's section carries its own changelog table, whose newest **N** row
+    // is that category's current version; this asserts the constants still match,
+    // reading the doc rather than restating it — the same approach
+    // scoring.test.ts takes, and for the same reason: a test that hardcodes the
+    // doc's number is a third copy to keep in sync.
+    //
+    // SCOPED PER CATEGORY, NOT FILE-WIDE. This used to take the max over every
+    // `**N**` row in the whole document, which was a correct reading while the
+    // file described one rulebook. It stopped being one when METHODOLOGY.md
+    // gained per-category sections: counters are independent and each starts at
+    // 1, so a file-wide max mixes two categories' numbering and silently
+    // compares lending's constant against whichever category happens to be
+    // furthest along. It is right today only because there is one category.
     const doc = repoFile('METHODOLOGY.md');
-    const versions = [...doc.matchAll(/^\|\s*\*\*(\d+)\*\*\s*\|/gm)].map((m) => Number(m[1]));
-    assert.ok(
-      versions.length > 0,
-      'could not parse the methodology version changelog out of METHODOLOGY.md — has its format changed?',
-    );
-    assert.equal(
-      Math.max(...versions),
-      METHODOLOGY_VERSIONS.lending,
-      "METHODOLOGY.md's newest published version differs from METHODOLOGY_VERSIONS.lending",
-    );
+
+    for (const category of PROTOCOL_CATEGORIES) {
+      const section = categorySection(doc, category);
+      const versions = [...section.matchAll(/^\|\s*\*\*(\d+)\*\*\s*\|/gm)].map((m) => Number(m[1]));
+      assert.ok(
+        versions.length > 0,
+        `could not parse ${category}'s version changelog out of METHODOLOGY.md — has its format changed?`,
+      );
+      assert.equal(
+        Math.max(...versions),
+        METHODOLOGY_VERSIONS[category],
+        `METHODOLOGY.md's newest published version for ${category} differs from METHODOLOGY_VERSIONS.${category}`,
+      );
+    }
   });
 });

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './category';
 export * from './types';
 export * from './adapter';
+export * from './weights';
 export * from './scoring';
 export * from './operational-state';

--- a/core/src/scoring.test.ts
+++ b/core/src/scoring.test.ts
@@ -25,7 +25,14 @@ import { describe, it } from 'node:test';
 // strip-only TypeScript mode rejects `enum` (ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX).
 // So the factor keys are written as string literals below, and a test asserts
 // those literals still match the enum — see "taxonomy names".
+import type { ProtocolCategory } from './category.ts';
 import type { RiskFactor, RiskFactorMap } from './types.ts';
+// A VALUE import: the weight declarations are the thing the doc's table is
+// pinned against, so they have to be readable at runtime, not just at compile
+// time. `weights.ts` is a leaf under the strip-only loader — its only import is
+// a type-only one — which is what makes this work.
+import { PROTOCOL_CATEGORIES } from './category.ts';
+import { CATEGORY_FACTORS } from './weights.ts';
 import {
   MIN_RESERVE_POOL_SHARE,
   STALE_CEILING_SECONDS,
@@ -57,27 +64,73 @@ function repoFile(name: string): string {
 const METHODOLOGY = repoFile('METHODOLOGY.md');
 
 /**
- * The "Factor weights" table: rows like ``| `oracleSafety` | 0.25 |``.
+ * The slice of METHODOLOGY.md belonging to one category: from its `## <Label>`
+ * heading down to the next heading of the same level.
+ *
+ * WHY THE PARSERS BELOW ARE SCOPED AND NO LONGER READ THE WHOLE FILE. The
+ * document used to describe exactly one rulebook, so "the weight table" and
+ * "the worked example" were unambiguous phrases and a file-wide regex was a
+ * correct reading of it. Per-category sections make both phrases ambiguous: a
+ * second category brings a second weight table and a second worked example,
+ * with its own factor keys and its own weights, and the old parsers would have
+ * concatenated the two tables and then asserted the pile summed to 1.00. That
+ * break would have surfaced in whatever change added the category, pointing at
+ * the wrong line. Taking a category and reading only its section is what makes
+ * each assertion below say which rulebook it is about.
+ *
+ * The heading text comes from `CATEGORY_FACTORS[category].label` rather than a
+ * literal here, so the document and the code cannot disagree about what a
+ * category's section is called — the same reason these parsers read the doc at
+ * all instead of restating it.
+ */
+function docCategorySection(category: ProtocolCategory): string {
+  const heading = `## ${CATEGORY_FACTORS[category].label}`;
+  const lines = METHODOLOGY.split('\n');
+  const start = lines.findIndex((l) => l.trimEnd() === heading);
+  assert.ok(
+    start >= 0,
+    `METHODOLOGY.md has no "${heading}" section. Every category in ` +
+      `PROTOCOL_CATEGORIES needs one — a category with no published rulebook is ` +
+      `a score nobody outside can check.`,
+  );
+
+  const rest = lines.slice(start + 1);
+  // `^## ` matches an h2 only: an h3 line starts `###`, so the space fails to
+  // match and a subsection cannot be mistaken for the end of the section.
+  const end = rest.findIndex((l) => /^## /.test(l));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/**
+ * One category's "Factor weights" table: rows like ``| `oracleSafety` | 0.25 |``.
  * The `Total` row is excluded by requiring a `*Safety` name.
  */
-function docWeightTable(): { factor: string; weight: number }[] {
-  const rows = [...METHODOLOGY.matchAll(/^\|\s*`(\w+Safety)`\s*\|\s*([\d.]+)\s*\|/gm)];
+function docWeightTable(category: ProtocolCategory): { factor: string; weight: number }[] {
+  const rows = [
+    ...docCategorySection(category).matchAll(/^\|\s*`(\w+Safety)`\s*\|\s*([\d.]+)\s*\|/gm),
+  ];
   assert.ok(
     rows.length > 0,
-    'could not parse the factor-weight table out of METHODOLOGY.md — has its format changed?',
+    `could not parse ${category}'s factor-weight table out of METHODOLOGY.md — has its format changed?`,
   );
   return rows.map((m) => ({ factor: m[1], weight: Number(m[2]) }));
 }
 
 /**
- * The worked example, e.g.
+ * One category's worked example, e.g.
  * `70×0.20 + 100×0.25 + 40×0.20 + 22×0.15 + 14×0.20 = 53.1 → 53`
  *
  * Returns the (value, weight) pairs plus the score the doc claims they produce.
  */
-function docWorkedExample(): { pairs: [number, number][]; stated: number; rounded: number } {
-  const line = METHODOLOGY.split('\n').find((l) => /×/.test(l) && /→/.test(l) && /\+/.test(l));
-  assert.ok(line, 'could not find the worked example line in METHODOLOGY.md');
+function docWorkedExample(category: ProtocolCategory): {
+  pairs: [number, number][];
+  stated: number;
+  rounded: number;
+} {
+  const line = docCategorySection(category)
+    .split('\n')
+    .find((l) => /×/.test(l) && /→/.test(l) && /\+/.test(l));
+  assert.ok(line, `could not find ${category}'s worked example line in METHODOLOGY.md`);
 
   const pairs = [...line.matchAll(/([\d.]+)×([\d.]+)/g)].map(
     (m) => [Number(m[1]), Number(m[2])] as [number, number],
@@ -115,9 +168,14 @@ function factorMap(entries: (RiskFactor | null)[]): RiskFactorMap {
 
 // ---------------------------------------------------------------------------
 
-describe('scoreFactors — agreement with METHODOLOGY.md', () => {
+describe("scoreFactors — agreement with METHODOLOGY.md's lending section", () => {
+  // Every assertion in here names the category it is about. `scoreFactors`
+  // itself is category-agnostic — it is a weighted mean and does not know which
+  // rulebook produced the weights — but a worked example and a weight table are
+  // a *category's*, so reading them without saying whose would be reading the
+  // wrong rulebook the moment a second one is published.
   it("reproduces the doc's worked example exactly", () => {
-    const { pairs, stated, rounded } = docWorkedExample();
+    const { pairs, stated, rounded } = docWorkedExample('lending');
 
     assert.equal(
       pairs.length,
@@ -150,7 +208,7 @@ describe('scoreFactors — agreement with METHODOLOGY.md', () => {
   });
 
   it("the doc's weight table sums to 1.00 and matches the worked example's weights", () => {
-    const table = docWeightTable();
+    const table = docWeightTable('lending');
     assert.equal(table.length, FACTOR_KEYS.length, 'expected five weighted factors');
 
     const sum = table.reduce((a, r) => a + r.weight, 0);
@@ -160,7 +218,7 @@ describe('scoreFactors — agreement with METHODOLOGY.md', () => {
     // worked example. They must agree with each other, or the doc contradicts
     // itself regardless of what the code does.
     const fromTable = table.map((r) => r.weight).sort();
-    const fromExample = docWorkedExample()
+    const fromExample = docWorkedExample('lending')
       .pairs.map(([, w]) => w)
       .sort();
     assert.deepEqual(
@@ -168,6 +226,47 @@ describe('scoreFactors — agreement with METHODOLOGY.md', () => {
       fromTable,
       "the worked example's weights differ from the table's",
     );
+  });
+
+  it("the published table is exactly what CATEGORY_FACTORS declares — the adapters' source", () => {
+    // THE LINK THAT MAKES THE CHAIN A CHAIN. Both adapters read their weights
+    // from `CATEGORY_FACTORS.lending`, and neither contains a weight literal
+    // any more; their suites assert they carry what it declares. This asserts
+    // the other end — that what it declares is what METHODOLOGY.md publishes.
+    // Without it, the two adapters could agree perfectly with each other and
+    // both disagree with the rulebook, which is worse than the drift the move
+    // into core was meant to fix, not better: it would look consistent.
+    //
+    // The doc is parsed, never restated, so a weight edited in either place
+    // alone fails here.
+    const fromDoc = Object.fromEntries(docWeightTable('lending').map((r) => [r.factor, r.weight]));
+    const declared = Object.fromEntries(
+      Object.entries(CATEGORY_FACTORS.lending.factors).map(([k, f]) => [k, f.weight]),
+    );
+
+    assert.deepEqual(
+      declared,
+      fromDoc,
+      'CATEGORY_FACTORS.lending and METHODOLOGY.md’s "Factor weights" table disagree. ' +
+        'Code and the doc are not allowed to drift — fix whichever is wrong, in the same change.',
+    );
+  });
+
+  it('publishes a rulebook section for every category that exists', () => {
+    // A category in PROTOCOL_CATEGORIES with no METHODOLOGY.md section is a
+    // score with no published rules behind it. `docCategorySection` throws with
+    // that message if the heading is missing, so iterating every category is the
+    // whole assertion — and it is the check that stops the next category being
+    // registered in code and forgotten in the document.
+    for (const category of PROTOCOL_CATEGORIES) {
+      const section = docCategorySection(category);
+      assert.ok(section.trim().length > 0, `${category}'s section in METHODOLOGY.md is empty`);
+      assert.ok(docWeightTable(category).length > 0, `${category} publishes no weight table`);
+      assert.ok(
+        docWorkedExample(category).pairs.length > 0,
+        `${category} publishes no worked example`,
+      );
+    }
   });
 
   it('taxonomy names agree across the enum, the doc, and this test', () => {
@@ -181,11 +280,16 @@ describe('scoreFactors — agreement with METHODOLOGY.md', () => {
 
     assert.deepEqual([...FACTOR_KEYS].sort(), fromEnum, 'FACTOR_KEYS is out of date with the enum');
     assert.deepEqual(
-      docWeightTable()
+      docWeightTable('lending')
         .map((r) => r.factor)
         .sort(),
       fromEnum,
-      "METHODOLOGY.md's weight table names a different set of factors than the enum",
+      "METHODOLOGY.md's lending weight table names a different set of factors than the enum",
+    );
+    assert.deepEqual(
+      Object.keys(CATEGORY_FACTORS.lending.factors).sort(),
+      fromEnum,
+      'CATEGORY_FACTORS.lending declares a different set of factors than the enum',
     );
   });
 });

--- a/core/src/scoring.ts
+++ b/core/src/scoring.ts
@@ -8,16 +8,32 @@
  * stays in the adapters — this file never reaches for chain data.
  */
 
-import type { RiskFactorComponent, RiskFactorMap, RiskScoreResult } from './types';
+import type { FactorMap, RiskFactorComponent, ScoreResult } from './types';
 
 /**
- * The overall score: a weighted mean of the five factors, renormalized over
+ * The overall score: a weighted mean of a category's factors, renormalized over
  * whichever are non-null.
  *
  * This is METHODOLOGY.md's "Score model" formula and it is emphatically **not**
- * per-protocol — ground rule 1 is that one rulebook applies to every adapter.
- * It lives here, and adapters call it, so two protocols cannot drift onto two
- * different weighted means. Do not reimplement it in an adapter.
+ * per-protocol — ground rule 1 is that one rulebook applies to every adapter in
+ * a category. It lives here, and adapters call it, so two protocols cannot drift
+ * onto two different weighted means. Do not reimplement it in an adapter.
+ *
+ * GENERIC OVER THE FACTOR MAP, AND DELIBERATELY NOT OVER THE CATEGORY. The
+ * weighted mean is the one piece of the rulebook that is genuinely
+ * category-agnostic: it reads `value` and `weight` and nothing else, so the key
+ * set it is handed cannot change what it computes. Typing it against lending's
+ * five-key `RiskFactorMap` said otherwise, and would have left the next category
+ * with a copy of this function to keep in sync — the exact drift this module
+ * exists to prevent. So the *type* widened to `FactorMap` and the body did not
+ * change by a character. There is no `scoreDexFactors` and there must never be
+ * one: which factors a category has, and what each is weighted, is data
+ * (`CATEGORY_FACTORS` in `weights.ts`) — never a second implementation of the
+ * mean.
+ *
+ * `M` flows straight through to the result, so a lending caller still gets a
+ * `RiskScoreResult` whose `factors` has exactly the five keys — widening the
+ * parameter narrowed nothing downstream.
  *
  * Renormalizing by the *observed* total weight (rather than dividing by a fixed
  * 1.0) is what makes a null factor genuinely excluded: a protocol for which one
@@ -28,7 +44,7 @@ import type { RiskFactorComponent, RiskFactorMap, RiskScoreResult } from './type
  * unsafe end rather than a division by zero, matching how the individual
  * factors treat "can't assess" (METHODOLOGY.md §1).
  */
-export function scoreFactors(factors: RiskFactorMap): RiskScoreResult {
+export function scoreFactors<M extends FactorMap>(factors: M): ScoreResult<M> {
   let weighted = 0;
   let totalWeight = 0;
   for (const factor of Object.values(factors)) {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -222,9 +222,39 @@ export interface RiskFactor {
  */
 export type RiskFactorMap = Record<RiskFactorType, RiskFactor | null>;
 
-export interface RiskScoreResult {
+/**
+ * Any category's factor map: factor keys to factors, with `null` for one that
+ * genuinely doesn't apply.
+ *
+ * `RiskFactorMap` above is **lending's** map — its keys are exactly the five
+ * `RiskFactorType` members. This is the shape all of them share, and it exists
+ * for one reason: `scoreFactors` is the weighted mean, and a weighted mean does
+ * not care which factors it is averaging. Typing that function against lending's
+ * key set made the arithmetic look category-specific when it never was, and the
+ * only way for a second category to reuse it would have been to copy it — which
+ * is the drift `core/src/scoring.ts` exists to prevent.
+ *
+ * WHAT THIS IS NOT. It is not an invitation to invent factor keys per adapter.
+ * Which keys a category scores is declared once in `CATEGORY_FACTORS`
+ * (`core/src/weights.ts`) and fixed there; this type is only what the shared
+ * arithmetic accepts, not a licence to widen a taxonomy.
+ */
+export type FactorMap = Record<string, RiskFactor | null>;
+
+/**
+ * The output of the shared weighted mean, parameterized by the factor map it
+ * was computed from so the map comes back out at the type it went in as.
+ *
+ * Defaulted to `RiskFactorMap`, which is why `RiskScoreResult` below is exactly
+ * the type it always was — every lending call site keeps its precise
+ * five-key `factors`, and nothing downstream had to widen.
+ */
+export interface ScoreResult<M extends FactorMap = RiskFactorMap> {
   /** 0-100, higher = safer */
   score: number;
-  factors: RiskFactorMap;
+  factors: M;
   computedAt: Date;
 }
+
+/** A lending score result. Unchanged in shape — see `ScoreResult`. */
+export type RiskScoreResult = ScoreResult<RiskFactorMap>;

--- a/core/src/weights.test.ts
+++ b/core/src/weights.test.ts
@@ -1,0 +1,93 @@
+// Tests for the per-category factor declarations.
+//
+// WHY THESE EXIST. `scoreFactors` renormalizes by the *observed* total weight,
+// not by a fixed 1.0 — that is what makes a null factor genuinely excluded
+// rather than counted as a zero (see `scoring.ts`). The cost of that design is
+// that a weight set which does NOT sum to 1.00 produces no symptom at all: the
+// mean still divides by whatever the weights add up to, and every score still
+// looks like a score. Nothing else in the codebase would notice. So the sum is
+// asserted here, per category, as the property the whole weighting rests on.
+//
+// The second half is the compile-time claim made runnable: `CATEGORY_FACTORS` is
+// declared `satisfies Record<ProtocolCategory, …>`, which catches a category
+// with no factor set but says nothing about a factor set with no factors, a
+// weight of 0, or a weight outside (0, 1]. Those are checked below.
+//
+// WHAT IS NOT TESTED HERE: whether lending's weights match METHODOLOGY.md. That
+// pinning lives in `scoring.test.ts`, which parses the published table out of
+// the document — a value restated in TypeScript is a third copy, not a check.
+//
+// Run with: pnpm --filter @stenion/core test
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+// VALUE imports, deliberately: this file is also the proof that both modules
+// load under the strip-only test runner. `weights.ts` imports `ProtocolCategory`
+// as a type only, so at runtime it is a leaf — if that import ever becomes a
+// value import, this file is where it shows up.
+import { PROTOCOL_CATEGORIES } from './category.ts';
+import { CATEGORY_FACTORS, LENDING_FACTORS } from './weights.ts';
+
+const categories = () => Object.entries(CATEGORY_FACTORS);
+
+describe('the per-category factor declarations', () => {
+  it('is value-importable under the test runner', () => {
+    assert.equal(typeof CATEGORY_FACTORS, 'object');
+  });
+
+  it('declares a factor set for every category, and no others', () => {
+    // The `satisfies` clause already requires every category to be present. This
+    // asserts the other direction — that nothing has been declared for a
+    // category the registry does not publish — and states the pairing in a form
+    // that fails loudly rather than being inferred from a type annotation.
+    assert.deepEqual(Object.keys(CATEGORY_FACTORS).sort(), [...PROTOCOL_CATEGORIES].sort());
+  });
+
+  it("every category's weights sum to 1.00", () => {
+    for (const [category, { factors }] of categories()) {
+      const sum = Object.values(factors).reduce((a, f) => a + f.weight, 0);
+      assert.ok(
+        Math.abs(sum - 1) < 1e-9,
+        `${category}'s factor weights sum to ${sum}, not 1.00. ` +
+          `scoreFactors divides by the observed total, so this would not fail ` +
+          `anywhere else — every score would just be quietly computed against ` +
+          `the wrong denominator.`,
+      );
+    }
+  });
+
+  it('gives every factor a real weight and a real label', () => {
+    for (const [category, { label, factors }] of categories()) {
+      assert.ok(label.length > 0, `${category} needs a display label`);
+      const keys = Object.keys(factors);
+      assert.ok(keys.length > 0, `${category} declares no factors`);
+
+      for (const [key, decl] of Object.entries(factors)) {
+        const where = `${category}.${key}`;
+        assert.match(key, /^[a-z][A-Za-z]*Safety$/, `${where}: factor keys end in *Safety`);
+        assert.ok(
+          decl.weight > 0 && decl.weight <= 1,
+          `${where}: weight ${decl.weight} is outside (0, 1]`,
+        );
+        assert.ok(decl.label.length > 0, `${where} needs a human label`);
+      }
+    }
+  });
+
+  it('has no two factors sharing a label within a category', () => {
+    // Two factors with the same display name are indistinguishable wherever the
+    // label is what a reader sees, which is the one job a label has.
+    for (const [category, { factors }] of categories()) {
+      const labels = Object.values(factors).map((f) => f.label);
+      assert.equal(new Set(labels).size, labels.length, `${category} reuses a factor label`);
+    }
+  });
+
+  it('exposes lending as the same object, not a copy', () => {
+    // `LENDING_FACTORS` is a convenience alias for the adapters to read. If it
+    // ever becomes a separate literal it becomes a second source of the weights,
+    // which is the whole thing this module was added to stop.
+    assert.equal(LENDING_FACTORS, CATEGORY_FACTORS.lending.factors);
+  });
+});

--- a/core/src/weights.ts
+++ b/core/src/weights.ts
@@ -1,0 +1,99 @@
+/**
+ * Each category's factor declarations: which factors its rulebook scores, what
+ * each one is weighted, and what to call it.
+ *
+ * WHY THIS EXISTS. A weight is a piece of the shared rulebook — METHODOLOGY.md
+ * ground rule 1 — and until now the ten numbers that make up lending's weighting
+ * were written out ten times, as `const weight = 0.25` literals inside the two
+ * adapters' factor methods. Nothing but review stopped one of them drifting, and
+ * a drift would not have been loud: both adapters would still have produced a
+ * plausible score, from two different weightings, and only the totals would have
+ * disagreed. That is precisely the failure `scoreFactors` was moved into core to
+ * prevent, applied to the numbers the mean is taken over rather than to the mean
+ * itself.
+ *
+ * WHY IT IS PER CATEGORY. A weight is only meaningful against a factor set, and
+ * the factor set is what a category *is* — `utilizationSafety` weighted 0.20
+ * means nothing to an AMM that has no borrow cap. So this is keyed the same way
+ * `CATEGORY_OPERATIONS` and `METHODOLOGY_VERSIONS` are, and for the same reason:
+ * a `Record<ProtocolCategory, …>` that has gained a key is a compile error at
+ * every place a new category must be registered.
+ *
+ * ONE ENTRY TODAY. Nothing here adds a category or a factor. What is scoped is
+ * *where lending's five weights are declared*, not what any of them is — every
+ * value below is the value METHODOLOGY.md has always published, and no score
+ * moved when they were gathered here.
+ *
+ * WHY A LEAF WITH ONE TYPE-ONLY IMPORT. `weights.test.ts` and
+ * `scoring.test.ts` both VALUE-import this module under `node --test`, whose
+ * type-stripping loader resolves an import graph literally. The
+ * `import type` below is erased before Node sees the file, so at runtime this
+ * module imports nothing at all — the same shape `category.ts` and
+ * `operational-state.ts` keep, and for the same reason. Don't add a value
+ * import here.
+ *
+ * WHAT THIS IS NOT. It is not the dashboard's label table. `FACTOR_ORDER` in
+ * `dashboard/app/lib/contract.ts` holds short *column headers* for a narrow
+ * table, on the dashboard's own hand-maintained mirror of the API contract —
+ * that mirror redeclares `RiskFactorMap` too, deliberately, so it does not
+ * import core. The labels here are the canonical human names for the factors,
+ * matching how METHODOLOGY.md titles each one.
+ */
+
+import type { ProtocolCategory } from './category';
+
+/**
+ * One factor's entry in a category's rulebook.
+ *
+ * `weight` is this factor's share of the overall score. A category's weights sum
+ * to 1.00 — asserted in `weights.test.ts`, because the renormalization in
+ * `scoreFactors` divides by the *observed* total and so would happily produce a
+ * confident-looking number from a set that summed to 0.9.
+ */
+export interface FactorDeclaration {
+  /** share of the overall score; a category's weights sum to 1.00 */
+  readonly weight: number;
+  /** canonical human name, e.g. "Oracle trustworthiness" */
+  readonly label: string;
+}
+
+/** A category's published factor set, keyed by factor key. */
+export interface CategoryFactors {
+  /** display name of the category — also its METHODOLOGY.md section heading */
+  readonly label: string;
+  readonly factors: Readonly<Record<string, FactorDeclaration>>;
+}
+
+/**
+ * Lending's five factors and their weights, in `RiskFactorType` order.
+ *
+ * These are METHODOLOGY.md's "Factor weights" table, and the two are pinned
+ * against each other by `scoring.test.ts` — which parses the table out of the
+ * document rather than restating it, so a drift in *either* direction fails.
+ * Both adapters then pin themselves against this map, so the chain runs
+ * adapter → here → the published rulebook with no hand-written copy in it.
+ *
+ * The weights themselves are an unvalidated judgment call and METHODOLOGY.md
+ * says so; this module is where they live, not an argument that they are right.
+ */
+export const CATEGORY_FACTORS = {
+  lending: {
+    label: 'Lending',
+    factors: {
+      collateralSafety: { weight: 0.2, label: 'Collateral concentration' },
+      oracleSafety: { weight: 0.25, label: 'Oracle trustworthiness' },
+      adminKeySafety: { weight: 0.2, label: 'Admin key control' },
+      liquiditySafety: { weight: 0.15, label: 'Free-liquidity depth' },
+      utilizationSafety: { weight: 0.2, label: 'Utilization headroom' },
+    },
+  },
+} as const satisfies Record<ProtocolCategory, CategoryFactors>;
+
+/**
+ * Lending's declarations, unwrapped — what the Blend and Kinetic adapters read.
+ *
+ * A convenience, not a second source: it is the same object
+ * `CATEGORY_FACTORS.lending.factors` names. An adapter reads
+ * `LENDING_FACTORS.oracleSafety.weight` where it used to write `0.25`.
+ */
+export const LENDING_FACTORS = CATEGORY_FACTORS.lending.factors;

--- a/dashboard/components/markdown-doc.tsx
+++ b/dashboard/components/markdown-doc.tsx
@@ -35,6 +35,13 @@ const components: Components = {
   // from elsewhere in the doc. Without an id those anchors work on GitHub and
   // silently dead-end on the site.
   h4: ({ children }) => <h4 id={slug(toText(children))}>{children}</h4>,
+  // h5/h6 for the same reason, and they exist because METHODOLOGY.md is now
+  // organized per category: every factor heading sits one level deeper under its
+  // category's section, so `#2e. The oracle-legibility precondition` — linked
+  // from §2 — moved from h4 to h5. Mapping every level the document can reach
+  // means a future nesting change cannot quietly break an in-page link again.
+  h5: ({ children }) => <h5 id={slug(toText(children))}>{children}</h5>,
+  h6: ({ children }) => <h6 id={slug(toText(children))}>{children}</h6>,
   // METHODOLOGY.md has several wide multi-column tables. A prose table is
   // width:100%, but its min-content width is set by its longest cell, so on a
   // narrow screen the table sets a floor on the page width and scrolls the whole


### PR DESCRIPTION
declare each category's factor weights once, not ten times across two adapters 
Closes #77 