### PR TITLE
chore: upgrade package manager to pnpm v11 (#90)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stenion",
   "private": true,
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@11.24.0",
   "engines": {
     "node": ">=22.18"
   },


### PR DESCRIPTION
## What this changes

Upgrades `packageManager` to `pnpm@11.24.0` in `package.json`.

Closes #90.

## Verification

- Installed dependencies via `pnpm@11.24.0`.
- Validated `package.json` structure and package manager resolution.

## Checklist

- [x] **Base branch is `dev`**, not `main`.
- [x] `pnpm format`, `pnpm build`, `pnpm lint`, `pnpm typecheck` all pass from the repo root.