### PR TITLE
feat(dashboard): accessibility pass on registry and detail pages (#20)

### DIFF
--- a/dashboard/app/(home)/page.tsx
+++ b/dashboard/app/(home)/page.tsx
@@ -70,14 +70,17 @@ export default async function HomePage() {
             <div className="mt-9 flex flex-wrap items-center gap-3">
               <Link
                 href="/registry"
-                className="group inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-bg transition-transform hover:-translate-y-0.5"
+                className="group inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-bg transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 Explore the registry
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                <ArrowRight
+                  className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
               </Link>
               <Link
                 href="/methodology"
-                className="inline-flex items-center gap-2 rounded-lg border border-line-strong px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent"
+                className="inline-flex items-center gap-2 rounded-lg border border-line-strong px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 Read the methodology
               </Link>
@@ -100,9 +103,9 @@ export default async function HomePage() {
             </div>
             <Link
               href="/registry"
-              className="hidden shrink-0 items-center gap-1 text-sm text-accent-ink transition-colors hover:text-ink sm:inline-flex"
+              className="hidden shrink-0 items-center gap-1 text-sm text-accent-ink transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm sm:inline-flex"
             >
-              All protocols <ArrowRight className="h-4 w-4" />
+              All protocols <ArrowRight className="h-4 w-4" aria-hidden="true" />
             </Link>
           </div>
         </Reveal>
@@ -110,7 +113,10 @@ export default async function HomePage() {
         {scored.length === 0 ? (
           <div className="mt-6 rounded-xl border border-line bg-surface p-6 text-sm text-muted">
             Live scores are warming up — the indexer hasn&apos;t published a run yet.{' '}
-            <Link href="/registry" className="text-accent-ink hover:underline">
+            <Link
+              href="/registry"
+              className="text-accent-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+            >
               Open the registry
             </Link>{' '}
             to check again.
@@ -277,18 +283,19 @@ export default async function HomePage() {
                 Ranked purely by safety score. Free, public, payment-blind.
               </p>
             </div>
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
               <Link
                 href="/registry"
-                className="inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-bg transition-transform hover:-translate-y-0.5"
+                className="inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-bg transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
-                Open the registry <ArrowRight className="h-4 w-4" />
+                Open the registry <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>
               <a
                 href={GITHUB_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-2 rounded-lg border border-line-strong px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent"
+                aria-label="Contribute an adapter on GitHub (opens in a new tab)"
+                className="inline-flex items-center gap-2 rounded-lg border border-line-strong px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 Contribute an adapter
               </a>

--- a/dashboard/app/coverage/[id]/page.tsx
+++ b/dashboard/app/coverage/[id]/page.tsx
@@ -88,9 +88,9 @@ export default async function CoveragePage({ params }: { params: Promise<{ id: s
       <Reveal>
         <Link
           href="/registry"
-          className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-ink"
+          className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
-          <ArrowLeft className="h-4 w-4" /> Registry
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Registry
         </Link>
       </Reveal>
 
@@ -301,11 +301,11 @@ function OutboundLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer nofollow"
-      aria-label={label}
+      aria-label={`${label} (opens in a new tab)`}
       title={title}
-      className="group inline-flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-sm text-muted transition-colors hover:border-accent hover:text-ink"
+      className="group inline-flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-sm text-muted transition-colors hover:border-accent hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
     >
-      {icon}
+      <span aria-hidden="true">{icon}</span>
       <span className={mono ? 'adapter-prose font-mono text-xs' : ''}>{value}</span>
     </a>
   );

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -43,6 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html
       lang="en"
       suppressHydrationWarning
+      data-scroll-behavior="smooth"
       className={`${GeistSans.variable} ${GeistMono.variable} ${display.variable}`}
     >
       <body className="min-h-screen bg-bg text-ink antialiased">
@@ -56,8 +57,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             already in <head>, and a synchronous inline script blocks parsing,
             so the attribute is set before any body content is laid out. */}
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT }} />
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-bg focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+        >
+          Skip to main content
+        </a>
         <Nav />
-        <main>{children}</main>
+        <main id="main-content">{children}</main>
         <Footer />
         {/* Vercel Analytics — client component that injects the pageview script.
             Renders no markup, so it sits last and can't affect layout. Pageviews

--- a/dashboard/app/protocol/[id]/page.tsx
+++ b/dashboard/app/protocol/[id]/page.tsx
@@ -69,9 +69,9 @@ export default async function ProtocolDetailPage({ params }: { params: Promise<{
       <Reveal>
         <Link
           href="/registry"
-          className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-ink"
+          className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
-          <ArrowLeft className="h-4 w-4" /> Registry
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Registry
         </Link>
       </Reveal>
 
@@ -416,15 +416,15 @@ function RefLink({
       target="_blank"
       // See ExternalRefs for why nofollow is here and not just noopener/noreferrer.
       rel="noopener noreferrer nofollow"
-      aria-label={label}
+      aria-label={`${label} (opens in a new tab)`}
       title={title}
-      className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+      className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${
         primary
           ? 'border-accent/40 bg-accent/5 text-ink hover:border-accent'
           : 'border-line text-muted hover:border-accent hover:text-ink'
       }`}
     >
-      {icon}
+      <span aria-hidden="true">{icon}</span>
       <span className={primary ? 'font-mono text-xs' : ''}>{value}</span>
     </a>
   );
@@ -439,7 +439,7 @@ function ScoreHistory({ history }: { history: HistoryEntry[] }) {
     <section className="mt-14">
       <Reveal>
         <div className="flex items-center gap-2">
-          <ActivitySquare className="h-4 w-4 text-accent" />
+          <ActivitySquare className="h-4 w-4 text-accent" aria-hidden="true" />
           <h2 className="font-display text-xl font-semibold text-ink">Score history</h2>
         </div>
         <p className="mt-1 text-sm text-muted">
@@ -480,9 +480,17 @@ function History({ history }: { history: HistoryEntry[] }) {
               older.methodologyVersion < h.methodologyVersion;
 
             return (
-              <li key={i}>
+              <li
+                key={i}
+                aria-label={`Run on ${formatTimestamp(h.runAt)}: ${
+                  h.status === 'ok'
+                    ? `scored ${h.safetyScore} out of 100`
+                    : `failed with error ${h.error}`
+                }`}
+              >
                 <div className="flex items-center gap-3 bg-surface/40 px-4 py-3 text-sm">
                   <span
+                    aria-hidden="true"
                     className={`h-2 w-2 shrink-0 rounded-full ${
                       h.status === 'ok' ? 'bg-safe' : 'bg-danger'
                     }`}
@@ -506,7 +514,10 @@ function History({ history }: { history: HistoryEntry[] }) {
                     Scoring rules changed here, so scores above and below this line are not
                     comparable. Earlier runs cannot be recomputed — only scores are stored, not the
                     on-chain inputs behind them.{' '}
-                    <Link href="/methodology" className="underline hover:text-ink">
+                    <Link
+                      href="/methodology"
+                      className="underline hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+                    >
                       What changed
                     </Link>
                   </div>

--- a/dashboard/app/registry/page.tsx
+++ b/dashboard/app/registry/page.tsx
@@ -272,7 +272,11 @@ function ResultSummary({
   if (coverage > 0) parts.push(`${coverage} assessed, not scored`);
 
   return (
-    <p className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-faint">
+    <p
+      aria-live="polite"
+      aria-atomic="true"
+      className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-faint"
+    >
       <span className="tnum">{parts.join(' · ') || 'No entries'}</span>
       {params.q !== '' && (
         <span>
@@ -282,7 +286,7 @@ function ResultSummary({
       {filtering && (
         <Link
           href="/registry"
-          className="font-medium text-accent-ink underline-offset-4 hover:underline"
+          className="font-medium text-accent-ink underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
         >
           Clear
         </Link>
@@ -499,7 +503,7 @@ function CoverageRow({ entry, chip }: { entry: CoverageEntry; chip: string }) {
     <Link
       id={`not-scored-${entry.id}`}
       href={`/coverage/${entry.id}`}
-      className="group grid scroll-mt-24 grid-cols-1 gap-2 px-4 py-4 transition-colors hover:bg-surface/50 md:grid-cols-[1fr_14rem] md:items-center md:gap-4"
+      className="group grid scroll-mt-24 grid-cols-1 gap-2 rounded-xl px-4 py-4 transition-colors hover:bg-surface/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg md:grid-cols-[1fr_14rem] md:items-center md:gap-4"
     >
       <div className="flex min-w-0 items-start gap-3">
         {/* Same tile as a scored row. The point of listing these is that they
@@ -510,7 +514,10 @@ function CoverageRow({ entry, chip }: { entry: CoverageEntry; chip: string }) {
         <span className="min-w-0">
           <span className="flex items-center gap-2">
             <span className="font-display text-base font-semibold text-ink">{entry.name}</span>
-            <ArrowUpRight className="h-3.5 w-3.5 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5" />
+            <ArrowUpRight
+              className="h-3.5 w-3.5 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5"
+              aria-hidden="true"
+            />
           </span>
           {/* Server-rendered, always open, never behind a disclosure: this
               sentence is what find-in-page and a search engine index, and it is
@@ -529,7 +536,10 @@ function CoverageRow({ entry, chip }: { entry: CoverageEntry; chip: string }) {
         <CoverageChip chip={chip} />
         <span className="inline-flex items-center gap-1 text-xs font-medium text-faint transition-colors group-hover:text-accent-ink">
           Why we don&rsquo;t score it
-          <ArrowRight className="h-3 w-3 transition-transform motion-safe:group-hover:translate-x-0.5" />
+          <ArrowRight
+            className="h-3 w-3 transition-transform motion-safe:group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
         </span>
       </div>
     </Link>
@@ -631,7 +641,7 @@ function MergedCoverageRow({ entry }: { entry: CoverageEntry }) {
       id={`not-scored-${entry.id}`}
       href={`/coverage/${entry.id}`}
       className={cn(
-        'group grid scroll-mt-24 grid-cols-1 gap-3 px-4 py-5 transition-colors hover:bg-surface/50 md:items-center md:gap-4',
+        'group grid scroll-mt-24 grid-cols-1 gap-3 rounded-xl px-4 py-5 transition-colors hover:bg-surface/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg md:items-center md:gap-4',
         GRID_UNRANKED,
       )}
     >
@@ -640,7 +650,10 @@ function MergedCoverageRow({ entry }: { entry: CoverageEntry }) {
         <span className="flex min-w-0 flex-col items-start">
           <span className="flex items-center gap-2">
             <span className="font-display text-lg font-semibold text-ink">{entry.name}</span>
-            <ArrowUpRight className="h-4 w-4 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5" />
+            <ArrowUpRight
+              className="h-4 w-4 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5"
+              aria-hidden="true"
+            />
           </span>
           <span className="adapter-prose mt-1 block text-sm leading-relaxed text-muted">
             {entry.summary}
@@ -662,7 +675,10 @@ function MergedCoverageRow({ entry }: { entry: CoverageEntry }) {
         Coverage note · not a score
         <span className="mt-1 flex items-center gap-1 font-medium transition-colors group-hover:text-accent-ink">
           Why we don&rsquo;t score it
-          <ArrowRight className="h-3 w-3 transition-transform motion-safe:group-hover:translate-x-0.5" />
+          <ArrowRight
+            className="h-3 w-3 transition-transform motion-safe:group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
         </span>
       </div>
     </Link>
@@ -690,21 +706,26 @@ function ProtocolRow({
   return (
     <Link
       href={`/protocol/${entry.id}`}
+      aria-label={
+        rank !== null
+          ? `Rank ${rank}: ${entry.name}, Chain: ${entry.chain}, Safety score: ${entry.safetyScore ?? 'unscored'} out of 100`
+          : `${entry.name}, Chain: ${entry.chain}, Safety score: ${entry.safetyScore ?? 'unscored'} out of 100`
+      }
       className={cn(
-        'group grid grid-cols-1 gap-3 px-4 py-5 transition-colors hover:bg-surface/50 md:items-center md:gap-4',
+        'group grid grid-cols-1 gap-3 rounded-xl px-4 py-5 transition-colors hover:bg-surface/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg md:items-center md:gap-4',
         rank === null ? GRID_UNRANKED : GRID_RANKED,
         stale && 'bg-accent/5 shadow-[inset_3px_0_0_0_var(--color-accent)] hover:bg-accent/9',
       )}
     >
       {rank !== null && (
-        <div className="tnum hidden text-sm text-faint md:block">
+        <div className="tnum hidden text-sm text-faint md:block" aria-hidden="true">
           {String(rank).padStart(2, '0')}
         </div>
       )}
 
       <div className="flex items-center gap-2">
         {rank !== null && (
-          <span className="tnum mr-1 text-sm text-faint md:hidden">
+          <span className="tnum mr-1 text-sm text-faint md:hidden" aria-hidden="true">
             {String(rank).padStart(2, '0')}
           </span>
         )}
@@ -727,7 +748,10 @@ function ProtocolRow({
         <span className="flex min-w-0 flex-col items-start">
           <span className="flex items-center gap-2">
             <span className="font-display text-lg font-semibold text-ink">{entry.name}</span>
-            <ArrowUpRight className="h-4 w-4 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5" />
+            <ArrowUpRight
+              className="h-4 w-4 text-faint transition duration-200 ease-out group-hover:text-accent-ink motion-safe:group-hover:translate-x-0.5 motion-safe:group-hover:-translate-y-0.5"
+              aria-hidden="true"
+            />
           </span>
           <span className="mt-1 flex flex-wrap items-center gap-1.5">
             <DeploymentBadge deployedOn={entry.deployedOn} />
@@ -744,12 +768,20 @@ function ProtocolRow({
         {entry.chain}
       </div>
 
-      <div>
+      <div
+        aria-label={
+          entry.safetyScore !== null
+            ? `Safety score: ${entry.safetyScore} out of 100`
+            : 'Safety score unavailable'
+        }
+      >
         <div className="flex items-baseline gap-2">
           <span className={`score-num text-2xl font-semibold ${bandTextClass(band)}`}>
             {entry.safetyScore ?? '—'}
           </span>
-          <span className="text-xs text-faint">/ 100</span>
+          <span className="text-xs text-faint" aria-hidden="true">
+            / 100
+          </span>
         </div>
         {/* The bar now fills on arrival, staggered down the list. It is the one
             element on the row that shows the score as a position on a scale

--- a/dashboard/components/code-block.tsx
+++ b/dashboard/components/code-block.tsx
@@ -71,8 +71,8 @@ export function CodeBlock({ raw, children }: { raw: string; children: React.Reac
         // Always visible rather than hover-only: half this page's readers are on a
         // phone, where there is no hover and a hidden affordance is no affordance.
         // Opaque background because the block scrolls horizontally underneath it.
-        className="cursor-pointer absolute right-2 top-2 inline-flex items-center gap-1.5 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-muted outline-none transition-colors hover:border-accent hover:text-ink focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent/60"
-        aria-label={copied ? 'Copied to clipboard' : 'Copy code to clipboard'}
+        className="cursor-pointer absolute right-2 top-2 inline-flex items-center gap-1.5 rounded-md border border-line bg-surface-2 px-2 py-1.5 text-xs font-medium text-muted transition-colors hover:border-accent hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        aria-label={copied ? 'Copied code to clipboard' : 'Copy code to clipboard'}
       >
         {copied ? (
           <Check className="h-3.5 w-3.5 text-safe" aria-hidden />

--- a/dashboard/components/deployment-badge.tsx
+++ b/dashboard/components/deployment-badge.tsx
@@ -52,6 +52,7 @@ export function DeploymentBadge({ deployedOn, className }: DeploymentBadgeProps)
       // title spells out the relationship for anyone who hovers, without
       // spending a second line of the row on it.
       title={`Not an independent protocol — this entry is a ${deployedOn.label}, running ${deployedOn.host}'s contracts.`}
+      aria-label={`Deployment: ${deployedOn.label}, running on ${deployedOn.host}'s contracts`}
     >
       <Layers className="h-3 w-3 shrink-0" aria-hidden="true" />
       {deployedOn.label}

--- a/dashboard/components/factor-bar.tsx
+++ b/dashboard/components/factor-bar.tsx
@@ -32,13 +32,18 @@ export function FactorCard({
 
   if (factor === null) {
     return (
-      <div className="surface-lit h-full rounded-xl border border-line-soft p-5">
+      <article
+        className="surface-lit h-full rounded-xl border border-line-soft p-5"
+        aria-label={`${label}: Not applicable to this protocol`}
+      >
         <div className="flex items-baseline justify-between gap-4">
           <span className="font-medium text-ink">{label}</span>
-          <span className="tnum text-sm text-faint">N/A</span>
+          <span className="tnum text-sm text-faint" aria-label="Not applicable">
+            N/A
+          </span>
         </div>
         <p className="mt-3 text-sm italic text-faint">Not applicable to this protocol.</p>
-      </div>
+      </article>
     );
   }
 
@@ -46,7 +51,10 @@ export function FactorCard({
   const pct = Math.max(0, Math.min(100, factor.value));
 
   return (
-    <div className="surface-lit h-full rounded-xl border border-line p-5 transition-colors hover:border-line/80">
+    <article
+      className="surface-lit h-full rounded-xl border border-line p-5 transition-colors hover:border-line/80"
+      aria-label={`${label} factor: score ${factor.value} out of 100, weight ${Math.round(factor.weight * 100)}%`}
+    >
       <div className="flex items-baseline justify-between gap-4">
         <span className="font-medium text-ink">
           {label}
@@ -54,12 +62,23 @@ export function FactorCard({
             weight {Math.round(factor.weight * 100)}%
           </span>
         </span>
-        <span className={`score-num text-lg font-semibold ${bandTextClass(band)}`}>
+        <span
+          className={`score-num text-lg font-semibold ${bandTextClass(band)}`}
+          aria-label={`Score ${factor.value} out of 100`}
+        >
           {factor.value}
         </span>
       </div>
 
-      <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-line-soft">
+      <div
+        className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-line-soft"
+        role="progressbar"
+        aria-label={`${label} safety score`}
+        aria-valuenow={factor.value}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={`${factor.value} out of 100`}
+      >
         <motion.div
           className="h-full rounded-full"
           style={{ background: bandColor(band) }}
@@ -78,7 +97,7 @@ export function FactorCard({
       {factor.components && factor.components.length > 0 && (
         <FactorComponents components={factor.components} featured={featured} />
       )}
-    </div>
+    </article>
   );
 }
 
@@ -140,12 +159,16 @@ function ComponentRow({ component: c }: { component: RiskFactorComponent }) {
         {c.value === null ? (
           // A null component is a deliberate disclosure, not missing data —
           // say so rather than rendering a bare dash the reader must guess at.
-          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-faint">
+          <span
+            className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-faint"
+            aria-label={`${c.label}: not scored disclosure`}
+          >
             not scored
           </span>
         ) : (
           <span
             className={`score-num shrink-0 text-sm font-semibold ${bandTextClass(scoreBand(c.value))}`}
+            aria-label={`${c.label} sub-score: ${c.value} out of 100`}
           >
             {c.value}
           </span>

--- a/dashboard/components/footer.tsx
+++ b/dashboard/components/footer.tsx
@@ -16,31 +16,45 @@ export function Footer() {
           </div>
 
           <div className="flex gap-12">
-            <nav className="flex flex-col gap-2 text-sm">
+            <nav aria-label="Site navigation" className="flex flex-col gap-2 text-sm">
               <span className="text-xs uppercase tracking-wider text-faint">Site</span>
               {NAV_LINKS.map((l) => (
-                <Link key={l.href} href={l.href} className="text-muted hover:text-ink">
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+                >
                   {l.label}
                 </Link>
               ))}
             </nav>
-            <nav className="flex flex-col gap-2 text-sm">
+            <nav aria-label="Community and documentation" className="flex flex-col gap-2 text-sm">
               <span className="text-xs uppercase tracking-wider text-faint">Open source</span>
               <a
                 href={GITHUB_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-muted hover:text-ink"
+                aria-label="GitHub (opens in a new tab)"
+                className="inline-flex items-center gap-1.5 text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
               >
-                <Github className="h-3.5 w-3.5" /> GitHub
+                <Github className="h-3.5 w-3.5" aria-hidden="true" /> GitHub
               </a>
-              <Link href="/methodology" className="text-muted hover:text-ink">
+              <Link
+                href="/methodology"
+                className="text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+              >
                 Methodology
               </Link>
-              <Link href="/docs/api" className="text-muted hover:text-ink">
+              <Link
+                href="/docs/api"
+                className="text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+              >
                 API docs
               </Link>
-              <Link href="/status" className="text-muted hover:text-ink">
+              <Link
+                href="/status"
+                className="text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-sm"
+              >
                 Status
               </Link>
             </nav>

--- a/dashboard/components/nav.tsx
+++ b/dashboard/components/nav.tsx
@@ -56,9 +56,12 @@ export function Nav() {
   return (
     <header className="sticky top-0 z-50 border-b border-line/70 bg-bg/70 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-6xl items-center gap-6 px-5">
-        <Link href="/" className="group flex items-center gap-2">
+        <Link
+          href="/"
+          className="group flex items-center gap-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
           <span className="grid h-7 w-7 place-items-center rounded-lg bg-accent/15 ring-1 ring-inset ring-accent/30">
-            <Radar className="h-4 w-4 text-accent" strokeWidth={2} />
+            <Radar className="h-4 w-4 text-accent" strokeWidth={2} aria-hidden="true" />
           </span>
           <span className="font-display text-lg font-semibold tracking-tight text-ink">
             Stenion
@@ -66,13 +69,16 @@ export function Nav() {
         </Link>
 
         {/* Desktop nav — unchanged layout, just hidden below md. */}
-        <nav className="ml-auto hidden items-center gap-1 text-sm md:flex">
+        <nav
+          aria-label="Main navigation"
+          className="ml-auto hidden items-center gap-1 text-sm md:flex"
+        >
           {NAV_LINKS.map((link) => (
             <Link
               key={link.href}
               href={link.href}
               className={cn(
-                'relative rounded-md px-3 py-2 transition-colors',
+                'relative rounded-md px-3 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
                 isActive(link.href) ? 'text-ink' : 'text-muted hover:text-ink',
               )}
             >
@@ -86,10 +92,10 @@ export function Nav() {
             href={GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            aria-label="Stenion on GitHub"
-            className="ml-1 grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink"
+            aria-label="Stenion on GitHub (opens in a new tab)"
+            className="ml-1 grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
-            <Github className="h-4 w-4" />
+            <Github className="h-4 w-4" aria-hidden="true" />
           </a>
           <ThemeToggle />
         </nav>
@@ -98,13 +104,17 @@ export function Nav() {
         <button
           ref={triggerRef}
           type="button"
-          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-label={open ? 'Close navigation menu' : 'Open navigation menu'}
           aria-expanded={open}
           aria-controls="mobile-menu"
           onClick={() => setOpen((v) => !v)}
-          className="ml-auto grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink md:hidden"
+          className="ml-auto grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent md:hidden"
         >
-          {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          {open ? (
+            <X className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <Menu className="h-5 w-5" aria-hidden="true" />
+          )}
         </button>
       </div>
 
@@ -124,6 +134,7 @@ export function Nav() {
             />
             <motion.nav
               id="mobile-menu"
+              aria-label="Mobile navigation"
               className="fixed inset-x-0 top-16 z-50 border-b border-line/70 bg-surface/95 backdrop-blur-xl"
               initial={{ opacity: 0, y: reduceMotion ? 0 : -8 }}
               animate={{ opacity: 1, y: 0 }}
@@ -138,7 +149,7 @@ export function Nav() {
                     ref={i === 0 ? firstLinkRef : undefined}
                     onClick={() => setOpen(false)}
                     className={cn(
-                      'rounded-md px-3 py-3 transition-colors',
+                      'rounded-md px-3 py-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
                       isActive(link.href)
                         ? 'bg-surface-2 text-ink'
                         : 'text-muted hover:bg-surface-2 hover:text-ink',
@@ -164,11 +175,11 @@ export function Nav() {
                     href={GITHUB_URL}
                     target="_blank"
                     rel="noreferrer"
-                    aria-label="Stenion on GitHub"
+                    aria-label="Stenion on GitHub (opens in a new tab)"
                     onClick={() => setOpen(false)}
-                    className="grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink"
+                    className="grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
-                    <Github className="h-4 w-4" />
+                    <Github className="h-4 w-4" aria-hidden="true" />
                   </a>
                   <ThemeToggle />
                 </div>

--- a/dashboard/components/operational-badge.tsx
+++ b/dashboard/components/operational-badge.tsx
@@ -64,6 +64,7 @@ export function OperationalBadge({ operationalState, className }: OperationalBad
       // reading and the plain-language consequence, so hovering answers "says
       // who?" without spending another line of the row.
       title={`${operationalState.detail} (read from ${operationalState.source}). Not scored — see the methodology.`}
+      aria-label={`Operational status: ${operationalLabel(operationalState.level)}. ${operationalState.detail}`}
     >
       <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
       {operationalLabel(operationalState.level)}

--- a/dashboard/components/protocol-carousel.tsx
+++ b/dashboard/components/protocol-carousel.tsx
@@ -333,6 +333,7 @@ function CarouselCard({
     <div className="w-[300px] shrink-0 pr-4 sm:w-[316px]">
       <Link
         href={`/protocol/${p.id}`}
+        aria-label={`${p.name}, Chain: ${p.chain}, Safety score: ${p.safetyScore ?? 'unscored'} out of 100`}
         style={{ '--sheen-delay': `${sheenDelay}s` } as React.CSSProperties}
         tabIndex={duplicate ? -1 : undefined}
         // `h-full` on a flex item in a stretch row: every card takes the height
@@ -340,7 +341,7 @@ function CarouselCard({
         // rather than standing proud of its neighbours.
         className={cn(
           'border-sheen group flex h-full flex-col rounded-xl border border-line surface-lit p-5',
-          'transition-all hover:-translate-y-0.5 hover:border-accent',
+          'transition-all hover:-translate-y-0.5 hover:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
         )}
       >
         <div className="flex items-center gap-4">

--- a/dashboard/components/protocol-logo.tsx
+++ b/dashboard/components/protocol-logo.tsx
@@ -60,6 +60,7 @@ export interface ProtocolLogoProps {
 export function ProtocolLogo({ name, logo, size = 40, className }: ProtocolLogoProps) {
   return (
     <div
+      aria-hidden="true"
       className={cn('shrink-0 overflow-hidden rounded-xl', className)}
       // Fixed dimensions in inline style, and matching width/height on the <img>
       // below, so the box occupies its final size on first paint. A slow or

--- a/dashboard/components/registry-controls.tsx
+++ b/dashboard/components/registry-controls.tsx
@@ -163,7 +163,7 @@ export function RegistryControls({
           // `search` inputs render a native clear affordance in some browsers;
           // the button below is the one that also clears the URL, so both being
           // present is deliberate rather than redundant.
-          className="w-full rounded-lg border border-line bg-surface py-2.5 pl-9 pr-9 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+          className="w-full rounded-lg border border-line bg-surface py-2.5 pl-9 pr-9 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
         {q !== '' && (
           <button
@@ -173,9 +173,9 @@ export function RegistryControls({
               go({ q: '' });
             }}
             aria-label="Clear search"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-faint transition-colors hover:text-ink"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-faint transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
-            <X className="h-3.5 w-3.5" />
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
         )}
       </div>
@@ -242,7 +242,7 @@ export function RegistryControls({
       <noscript>
         <button
           type="submit"
-          className="rounded-lg border border-line px-4 py-2.5 text-sm font-medium text-ink"
+          className="rounded-lg border border-line px-4 py-2.5 text-sm font-medium text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           Search
         </button>
@@ -274,9 +274,10 @@ function Select({
       <select
         id={id}
         name={name}
+        aria-label={label}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded-lg border border-line bg-surface px-3 py-2.5 text-sm text-ink focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent sm:w-auto"
+        className="w-full rounded-lg border border-line bg-surface px-3 py-2.5 text-sm text-ink focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:w-auto"
       >
         {children}
       </select>

--- a/dashboard/components/score-bar.tsx
+++ b/dashboard/components/score-bar.tsx
@@ -38,7 +38,10 @@ export function ScoreBar({
   const band = scoreBand(score);
 
   return (
-    <div className={`h-1.5 w-full overflow-hidden rounded-full bg-line-soft ${className ?? ''}`}>
+    <div
+      aria-hidden="true"
+      className={`h-1.5 w-full overflow-hidden rounded-full bg-line-soft ${className ?? ''}`}
+    >
       {score !== null && (
         <motion.div
           className="h-full rounded-full"

--- a/dashboard/components/score-history-chart.tsx
+++ b/dashboard/components/score-history-chart.tsx
@@ -136,7 +136,7 @@ export function ScoreHistoryChart({ history }: { history: HistoryEntry[] }) {
           }
         }}
         onBlur={() => setActive(null)}
-        className="relative rounded-xl border border-line surface-lit p-2 outline-none focus-visible:border-accent focus-visible:ring-1 focus-visible:ring-accent/60"
+        className="relative rounded-xl border border-line surface-lit p-2 outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
       >
         <svg
           ref={svgRef}

--- a/dashboard/components/score-ring.tsx
+++ b/dashboard/components/score-ring.tsx
@@ -86,8 +86,18 @@ export function ScoreRing({
       style={{ width: size, height: size }}
       viewport={VIEWPORT}
       onViewportEnter={() => setSeen(true)}
+      role="meter"
+      aria-label={
+        score === null
+          ? 'Safety score: not yet scored'
+          : `Safety score: ${score} out of 100 (${band} band). Scale 0 to 100, higher is safer.`
+      }
+      aria-valuenow={score ?? undefined}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuetext={score === null ? 'Not scored' : `${score} out of 100`}
     >
-      <svg width={size} height={size} className="-rotate-90">
+      <svg width={size} height={size} className="-rotate-90" aria-hidden="true">
         <circle
           cx={size / 2}
           cy={size / 2}
@@ -117,7 +127,7 @@ export function ScoreRing({
           />
         )}
       </svg>
-      <div className="absolute inset-0 grid place-items-center text-center">
+      <div className="absolute inset-0 grid place-items-center text-center" aria-hidden="true">
         <div>
           <div
             className="score-num font-semibold leading-none"

--- a/dashboard/components/status-pill.tsx
+++ b/dashboard/components/status-pill.tsx
@@ -31,17 +31,22 @@ export function StatusPill({
         freshnessPillClass(tone),
         className,
       )}
+      aria-label={`Freshness status: ${label}`}
     >
       {tone === 'live' && (
-        <span className="relative flex h-1.5 w-1.5">
+        <span className="relative flex h-1.5 w-1.5" aria-hidden="true">
           {/* The ping is the one piece of motion here; a reader who asked for
               none gets the same dot, static, rather than a different layout. */}
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-safe opacity-60 motion-reduce:animate-none" />
           <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-safe" />
         </span>
       )}
-      {tone === 'stale' && <RefreshCwOff className="h-3.5 w-3.5" strokeWidth={2} />}
-      {tone === 'unscored' && <CircleSlash className="h-3.5 w-3.5" strokeWidth={2} />}
+      {tone === 'stale' && (
+        <RefreshCwOff className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+      )}
+      {tone === 'unscored' && (
+        <CircleSlash className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+      )}
       {label}
     </span>
   );

--- a/dashboard/components/theme-toggle.tsx
+++ b/dashboard/components/theme-toggle.tsx
@@ -253,7 +253,7 @@ export function ThemeToggle({ className }: { className?: string }) {
             setOpen(true);
           }
         }}
-        className="grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink"
+        className="grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
       >
         <ResolvedIcon className="h-4 w-4" strokeWidth={2} />
       </button>
@@ -279,11 +279,11 @@ export function ThemeToggle({ className }: { className?: string }) {
                 onClick={(e) => select(value, e)}
                 onKeyDown={(e) => onItemKeyDown(e, i)}
                 className={cn(
-                  'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors',
+                  'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
                   selected ? 'text-ink' : 'text-muted hover:bg-surface-2 hover:text-ink',
                 )}
               >
-                <Icon className="h-4 w-4 shrink-0" strokeWidth={2} />
+                <Icon className="h-4 w-4 shrink-0" strokeWidth={2} aria-hidden="true" />
                 <span className="flex-1">{label}</span>
                 {value === 'system' && (
                   <span className="text-xs text-faint">{systemIsDark ? 'Dark' : 'Light'}</span>
@@ -291,6 +291,7 @@ export function ThemeToggle({ className }: { className?: string }) {
                 <Check
                   className={cn('h-3.5 w-3.5 shrink-0 text-accent', !selected && 'invisible')}
                   strokeWidth={2.5}
+                  aria-hidden="true"
                 />
               </button>
             );


### PR DESCRIPTION
## What this changes

Implements a comprehensive accessibility pass across the registry, protocol detail, and coverage pages to improve screen reader semantics, score clarity, and keyboard navigation.

Closes #20.

### Key improvements:
- **Score Scale & Direction Semantics**:
  - `ScoreRing`: Added `role="meter"` with full scale and direction context (`aria-label="Safety score: X out of 100 (... band). Scale 0 to 100, higher is safer"`), and hid animated counting elements from screen reader noise.
  - `ScoreBar`: Marked with `aria-hidden="true"` to prevent duplicate raw number announcements.
  - `ProtocolRow`: Explicitly labels safety score and rank for screen readers.
- **Factor Breakdown Navigation**:
  - `FactorCard`: Added `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and weight descriptions.
  - `FactorComponents`: Added descriptive labels for scored sub-signals and deliberate "not scored" disclosures.
- **Keyboard Navigation & Visible Focus Rings**:
  - Added high-contrast `focus-visible:` rings across all interactive elements: search input, filter selects, clear buttons, registry rows, detail reference links, navigation links, and theme toggle.
  - Added direct `aria-label` to all `<select>` filter dropdowns.
  - Added a "Skip to main content" link and `<main id="main-content">` landmark.
- **Semantic Announcements & Links**:
  - Added `aria-live="polite"` to `ResultSummary` for dynamic search/filter updates.
  - Added `(opens in a new tab)` announcements to all external reference links (`target="_blank"`).
  - Decorated visual-only icons and logos with `aria-hidden="true"`.
  - Added distinct accessible names to footer and header `<nav>` landmarks.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm -r build`, and `pnpm test` all passed (184/184 tests passing).
- Verified keyboard tab navigation order and visible focus indicators across all interactive elements.
- Verified ARIA roles and labels for screen reader clarity.

## Checklist

- [x] **Base branch is `dev`**, not `main`.
- [x] `pnpm format`, `pnpm build`, `pnpm lint`, `pnpm typecheck` all pass from the repo root.
- [x] Score displays carry accessible labels conveying scale and direction.
- [x] All interactive elements are reachable and operable by keyboard with visible focus states.