### PR TITLE
Fix/ignore dashboard agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 .next/
 out/
 next-env.d.ts
+dashboard/AGENTS.md
+dashboard/CLAUDE.md
 # Legacy indexer run log (step 4 interim storage; superseded by Postgres in step 5)
 runs.jsonl
 .env


### PR DESCRIPTION
> ## ⚠️ Target the `dev` branch — not `main`
>
> `main` is what Vercel auto-deploys, so a PR merged there goes straight to production.
> All contributions land on `dev` first. If the base branch above says `main`, change it
> to `dev` before you submit — use **Edit** next to the PR title.

## What this changes

Adds `dashboard/AGENTS.md` and `dashboard/CLAUDE.md` to `.gitignore` so the files generated by Next.js during local dashboard development are not accidentally committed.

Fixes #117

## Verification

- Ran the dashboard locally and confirmed both agent files were generated.
- Confirmed both generated files are ignored by Git and do not appear in `git status`.
- Confirmed the dashboard returned HTTP 200.
- `pnpm format` passes.
- `pnpm build` passes.
- `pnpm lint` passes.
- `pnpm typecheck` passes.
- `git diff --check` passes.
- Final working tree is clean.

## Checklist

- [x] **Base branch is `dev`**, not `main`.
- [x] `pnpm format`, `pnpm build`, `pnpm lint`, `pnpm typecheck` all pass from the repo root.
- [ ] Every on-chain method/field name is confirmed against the protocol's audited source or SDK —
      linked above, not guessed.
- [ ] All five `*Safety` factors are implemented per `methodology/` (or `null` with a real
      reason), each with a meaningful `detail` string.
- [ ] No fabricated numbers — a factor without real data uses a clearly-flagged neutral baseline.
- [ ] `methodology/` is updated in this PR if a formula, threshold, weight, or per-protocol
      anchoring fact changed. Code and methodology are not allowed to drift.
- [x] Any new dependency is called out explicitly above, with justification. (No new dependencies.)