### PR TITLE
Shard indexer targets across multiple cron invocations to break Vercel's 60s ceiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ These override any default behavior and are enforced in code and review:
 ## Code conventions
 
 - **Package manager: pnpm**, via corepack. The version is pinned by the `packageManager` field in
-  the root `package.json` (currently `pnpm@9.15.9`), and that field is the **only** place it is
+  the root `package.json` (currently `pnpm@11.24.0`), and that field is the **only** place it is
   declared: CI's `pnpm/action-setup` step deliberately passes no `version:` input and reads the same
   field, so a contributor's local pnpm and CI's cannot diverge. Corepack enforces it — with
   `corepack enable` done, `pnpm --version` inside this repo reports the pinned version regardless of
@@ -163,6 +163,24 @@ These override any default behavior and are enforced in code and review:
   into agreeing on a number nobody reviewed. It is a state to leave, not to live in — `dex` passed
   through it — admitted as a factor set, weighted in a later review — and **no category is in it
   today**; it is kept for the next one admitted the same way.
+  **A weight is a plain `number`, and branding it was considered and REJECTED.** The proposal was a
+  `FactorWeight` nominal type constructible only inside `weights.ts`, threaded through
+  `RiskFactor.weight`, so that a `weight: 0.33` literal in an adapter would not typecheck. It is
+  rejected on three findings, all checked rather than argued: (a) the hazard it was aimed at —
+  reading `.weight` off an unweighted declaration — is **already a compile error through every
+  spelling**, including the unwrapped alias, because `as const satisfies` gives `LENDING_FACTORS` /
+  `DEX_FACTORS` the literal declaration type rather than `CategoryFactors`, so an alias inherits the
+  narrowing instead of laundering it (`TS2339`, verified); (b) the residual hazard, a bare literal,
+  is caught by a **test** and not merely by review — each adapter's `score.test.ts` pins every
+  factor's `weight` against the declaration table, so a literal fails `pnpm test`; and (c) the brand
+  cannot cross the storage boundary honestly — `HistoryRow`/`ProtocolDetailRow` describe a
+  `risk_scores` row as pg returns it, jsonb deserializes to a plain `number`, and asserting a brand
+  there would reintroduce exactly the read-side lie that `as RiskFactorMap` → `as FactorMap` removed.
+  A brand that tests must be able to construct is a speed bump, not a closed hole: the 13 synthetic
+  weights in `core`/`db`/`indexer` exist to exercise values no real table has. **What would revisit
+  it:** an adapter shipping a weight literal that the pin tests did not catch — i.e. a real escape,
+  not a hypothetical one. Adding a category, or one sitting in `pendingWeights`, is **not** grounds
+  on its own; that case is (a), and it already fails to compile.
 - **An adapter is a FOLDER of four files, and only `index.ts` is API.** `adapters/<protocol>/`
   holds `types.ts` (mainnet wiring, constants, raw on-chain shape, options), `fetch.ts` (everything
   touching RPC/Horizon, plus decoders, behind one `fetch*` entry point), `score.ts` (the five

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,13 @@ former transitional aliases were removed and now 404, and the versioning policy 
 in-process (no HTTP hop). The indexer is triggered by a secret-gated cron route
 (`POST /api/cron/run-indexer`), which an external cron-job.org job POSTs to every 5 minutes with
 `Authorization: Bearer <CRON_SECRET>`. That schedule lives in the cron-job.org dashboard, **not in
-this repo** — there is no workflow or `vercel.json` `crons` entry to find. `@stenion/api` is legacy —
+this repo** — there is no workflow or `vercel.json` `crons` entry to find. The route takes an
+optional `?shard=<i>&totalShards=<n>`, scoring one shard of the registry so that **one job per
+shard** covers more targets than one invocation can (both params or neither; a half-configured or
+unmatchable spec is a 400, never a quiet no-op). Which target lands where is `selectShard` in
+`indexer/src/cycle.ts`; the job table and the **staggering rule** — shards must not fire on the
+same minute, or they put concurrent load on the RPC that `STENION_CYCLE_CONCURRENCY` cannot see —
+are in `architecture/deploy-architecture.md`. `@stenion/api` is legacy —
 kept but not deployed. Env vars: `DATABASE_URL` (Neon pooled), `STENION_RPC_URL`,
 `STENION_HORIZON_URL`, `CRON_SECRET`, plus optional `STENION_ALERT_WEBHOOK_URL` (indexer failure
 alerts; unset = off), `STENION_RATE_LIMIT_SALT`, and the retry/threshold, rate-limit and
@@ -281,18 +287,28 @@ rule here is that **caching must never mask `lastRunAt`/`lastRunStatus`**, which
 computed per response from the body rather than being a constant.
 
 > **The 60s ceiling is load-bearing.** `maxDuration` is capped at 60 on Vercel's Hobby tier and
-> cannot be raised. The indexer's retry budget (`STENION_CYCLE_BUDGET_MS`, default 42s) exists to
+> cannot be raised. The indexer's retry budget (`STENION_CYCLE_BUDGET_MS`, default 50s) exists to
 > stay inside it: a cycle killed mid-flight can leave one protocol scored and the other neither
 > scored nor recorded as failed, which is worse than a clean failure. Raise the budget only against
 > observed cycle durations, never by arithmetic alone.
 >
 > **The budget is NOT divided per target, and must not go back to being.** Targets run through a
-> bounded worker pool (`STENION_CYCLE_CONCURRENCY`, default 2) and each gets the end of the budget
+> bounded worker pool (`STENION_CYCLE_CONCURRENCY`, default 1) and each gets the end of the budget
 > less one full attempt reserved per queued wave (`targetDeadline`). A rule where a target's
 > deadline shrinks as the registry grows can fail protocols that already work — that is what
 > `budgetMs / targetCount` did, and it was removed. The replacement's ceiling is the explicit
 > condition `ceil(targets / concurrency) * attemptTimeoutMs <= budgetMs`, checked by
 > `cycleFeasibility()` and warned about every cycle, never discovered by adding a pool.
+>
+> **That ceiling is PER INVOCATION, and the registry is not.** It allows five targets at the
+> shipped defaults; `runCycle` only ever receives one shard's targets, so the condition is checked
+> against that subset and `n` shards carry `5n`. Capacity is bought by provisioning another
+> cron-job.org job, **not** by raising the budget — 60s of attempts is the `maxDuration` ceiling
+> itself. Shard assignment is a balanced deal over `(hash(id), id)` rather than `hash % n`,
+> because balance is what makes `n` shards worth `5n`; the cost is that registering a target can
+> move an existing one between shards, which is safe **only because nothing is keyed by shard** —
+> streaks are derived per protocol from `risk_scores`. If anything ever is keyed by shard, that
+> is the decision to revisit.
 >
 > **`STENION_CYCLE_CONCURRENCY` ships at 1, and raising it is a measurement question, not a
 > judgement call.** It shipped at 2 and was reverted the same day when the free shared public RPC

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,70 +217,71 @@ commitment — priorities shift as protocols launch and as the project finds fun
   invariant holds for links as well as for the registry; `/coverage` with no id redirects to the
   registry filtered to those entries.
 
+- **Sharding the registry across cron invocations.** The five-target ceiling was a per-_invocation_
+  ceiling, and it still is; what changed is that the registry no longer has to fit in one
+  invocation. `POST /api/cron/run-indexer?shard=<i>&totalShards=<n>` scores one shard, `n`
+  cron-job.org jobs cover the registry, and `cycleFeasibility()` is evaluated against each shard's
+  own subset — so `n` shards carry `5n` targets.
+
+  **Freshness is NOT the cost, and this roadmap previously said it would be.** The entry that
+  tracked this blocker costed sharding as "a five-minute cadence over three shards is a
+  fifteen-minute worst case per market", and that is true of the shape it assumed — one job
+  rotating through subsets on successive invocations. The shape that shipped is `n` **separate
+  jobs, each every 5 minutes, staggered by a minute**. Every target is still scored every 5
+  minutes, so `STENION_HEALTH_STALE_MINUTES` and `STENION_ALERT_THRESHOLD` keep their meanings and
+  nothing had to be retuned. The staggering is load-bearing rather than tidy:
+  `STENION_CYCLE_CONCURRENCY` bounds parallel targets _within_ an invocation and cannot see another
+  invocation, so simultaneous shards would reproduce the concurrency-2 `429` incident from a
+  direction the config does not control.
+
+  **Assignment is a balanced deal, not `hash % n`, and that was the one real decision.** Targets
+  are sorted by `(hash(id), id)` and dealt round-robin, which keeps shards within one target of
+  each other — the property that makes `n` shards worth `5n` slots. The alternative that keeps a
+  target's shard a function of its own slug alone was measured against this registry and rejected:
+  today's five slugs land **4 and 1** across two shards. The cost of the balanced deal is that
+  registering a target can move an existing one between shards, which is safe here for a specific
+  reason — **nothing is keyed by shard.** Streaks are derived per protocol from `risk_scores`
+  (`alerts.ts`, "WHY DERIVE"), so a move cannot reset or double-count one; `cycle.test.ts` pins
+  that a target reaches a byte-identical alert decision sharded and unsharded.
+
+  **Alerting is one POST per shard invocation** where it was one per cycle — an RPC-wide outage now
+  reads as `n` messages covering disjoint target sets. Weighed and accepted; it also relieves the
+  `MAX_MESSAGE_CHARS` truncation `alerts.ts` documents.
+
+  Job table, staggering, and the full reasoning:
+  [`architecture/deploy-architecture.md`](architecture/deploy-architecture.md) "Sharding the
+  registry across invocations". **The mechanism is shipped; the capacity is not bought until the
+  extra cron-job.org jobs exist**, which is infra config outside this repo.
+
 - **The full stack:** on-chain adapters → indexer → Postgres → API → dashboard, deployed as a single
   Vercel project with external (cron-job.org) scheduling. See [`architecture/index.md`](architecture/index.md).
 
 ## Planned
 
 Roughly in priority order, but not committed to dates. **The first item gates every other item that
-adds a market**, so it is first in fact and not only in presentation.
+adds a market** — it used to be a hard blocker with no mechanism behind it; it is now a matter of
+provisioning the shards that sharding made possible.
 
-- **BLOCKER — the registry is full at five targets. Nothing can be registered until scheduling is
-  solved.** Not "the next dex market"; **nothing**. Not a sixth Aquarius pool, not a fifth Blend
-  market, not a new adapter for a protocol that clears every gate in
-  [`TAXONOMY.md`](TAXONOMY.md) and passes every per-pool verification there is. Verification is no
-  longer what decides whether a market gets scored — capacity is, and capacity is exhausted.
+- **Register more markets — the mechanism exists, the jobs do not yet.** Sharding shipped (see
+  "Shipped" above), so the registry ceiling is now `5 x <number of cron-job.org jobs>` rather than a
+  flat five. Nothing further is registered yet, because buying the capacity means adding those jobs
+  in the cron-job.org dashboard — infra config outside this repo, with the job table in
+  [`architecture/deploy-architecture.md`](architecture/deploy-architecture.md).
 
-  **Why it is a hard stop and not a tight fit.** One scoring cycle is one serverless invocation.
-  `cycleFeasibility()` requires that every registered target can get one full attempt inside the
-  cycle budget:
+  **The per-shard five is unchanged and still pinned by measurement.** Within one invocation,
+  `ceil(targets / concurrency) * STENION_ATTEMPT_TIMEOUT_MS <= STENION_CYCLE_BUDGET_MS` still holds
+  at 50,000ms / 10,000ms / concurrency 1, and all three dials are where the deployed measurements
+  put them:
 
-  ```
-  ceil(targets / concurrency) * STENION_ATTEMPT_TIMEOUT_MS <= STENION_CYCLE_BUDGET_MS
-  ```
+  | Dial                         | Where it is | Why it has not moved                                                                                                                                                                                                                                                                       |
+  | ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+  | `STENION_CYCLE_BUDGET_MS`    | 50,000      | 60,000 is the `maxDuration` ceiling itself, so the next step up is the cliff. Sharding is what replaced raising it.                                                                                                                                                                        |
+  | `STENION_CYCLE_CONCURRENCY`  | 1           | Shipped at 2 and reverted the same day when `mainnet.sorobanrpc.com` started refusing the target behind the burst. Raising it needs a **deployed** RPC-tolerance measurement, never an estimate.                                                                                           |
+  | `STENION_ATTEMPT_TIMEOUT_MS` | 10,000      | The 2026-08-30 reading makes a case for lowering it — the slowest healthy attempt is kinetic at 5.5s — but `DEFAULT_RATE_LIMIT_POLICY` spends up to 2,000ms of that cap waiting out `429`s, leaving thinner margin than the durations suggest. Its own decision, with its own measurement. |
 
-  At the shipped defaults — concurrency **1**, attempt timeout **10,000ms** — five targets need
-  `5 × 10,000 = 50,000ms`, and `STENION_CYCLE_BUDGET_MS` is **50,000**. It fits exactly, with zero
-  headroom. A sixth target needs **60,000ms**, and that is not a budget that can be granted: it
-  **is** Vercel Hobby's `maxDuration`, which cannot be raised on this tier, and a cycle killed
-  mid-flight can leave one market scored and another neither scored nor recorded as failed — worse
-  than a clean failure, which is the whole reason a budget below the ceiling exists.
-
-  **All three dials are already at their limit, and each is pinned by something measured:**
-
-  | Dial                         | Where it is | Why it cannot move                                                                                                                                                                                                                                 |
-  | ---------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `STENION_CYCLE_BUDGET_MS`    | 50,000      | Raised from 42,000 against three `curl`ed deployed cycles. 60,000 is the `maxDuration` ceiling itself, so the next step up is the cliff.                                                                                                           |
-  | `STENION_CYCLE_CONCURRENCY`  | 1           | Shipped at 2 and reverted the same day when `mainnet.sorobanrpc.com` — free, shared, keyless — started refusing the target behind the burst. Raising it again needs a **deployed** RPC-tolerance measurement, never an estimate.                   |
-  | `STENION_ATTEMPT_TIMEOUT_MS` | 10,000      | Already lowered 15s → 10s to buy the fourth target. The registry's most expensive attempt (an Aquarius pool: 37 requests against Blend's 16) sits at an estimated 5.5–8.7s deployed, so a lower cap would time out a healthy target on a slow day. |
-
-  **What actually unblocks it: sharding, or staggered scheduling.** Not a config change — a change
-  to what a cron invocation _is_. Today one POST scores every target; the fix is that a POST scores
-  a _subset_, with successive invocations covering the registry in rotation. Two shapes are worth
-  costing:
-
-  - **Sharding by target group** — the dex targets and the lending targets on separate invocations,
-    each with its own budget. Cheapest to reason about; makes the cron-job.org side two jobs instead
-    of one.
-  - **Round-robin over a stable order** — each invocation takes the `N` targets least recently
-    scored. Scales to any registry size without a second job, at the cost of making a protocol's
-    freshness a function of how many protocols there are.
-
-  **Whichever wins, `/api/v1/health` is the precondition**, and it already exists. A target skipped
-  by a shard has to go _visibly_ stale rather than silently — `staleMinutes` climbing on the status
-  page is the difference between "we score this every 15 minutes now" and "we quietly stopped
-  scoring this". The staleness threshold has to move with the cadence, or the endpoint starts
-  reporting `degraded` for a schedule working as designed.
-
-  **The cost is honest and has to be stated up front:** sharding trades freshness for coverage. A
-  five-minute cadence over three shards is a fifteen-minute worst case per market, and
-  "continuous, on-chain-derived risk scoring" is the pitch. That trade is a decision, not an
-  implementation detail — it is the reason this is a tracked blocker rather than a task someone
-  picks up quietly.
-
-  Until it is made, the honest answer to "can you score X?" is **yes, and it will not be
-  registered** — which is exactly what `coverage.ts`'s `awaiting-capacity` status says on the
-  registry, for the 339 Aquarius markets already in that position. See
+  So the honest answer to "can you score X?" is now **yes, once there is a job for its shard** —
+  which is what `coverage.ts`'s `awaiting-capacity` status says on the registry for the 339
+  Aquarius markets in that position. See
   [`architecture/deploy-architecture.md`](architecture/deploy-architecture.md) for the deployed
   measurements behind every number above.
 
@@ -428,10 +429,8 @@ adds a market**, so it is first in fact and not only in presentation.
   only under the division rule that has been removed. An unmeasured target sorts first, i.e. is
   assumed slowest.
 
-  Still open: **sharding targets across cron invocations** — written here as a contingency for RPC
-  rate limits, and promoted since to the blocker at the top of this section. It is no longer a last
-  resort held in reserve: with the budget at its ceiling and concurrency pinned at 1, it is the only
-  remaining way to register anything at all.
+  **Resolved by sharding**, which shipped: the budget-and-concurrency ceiling is per invocation,
+  and the registry is now split across several. See the sharding entry under "Shipped".
 
 - **An `AbortSignal` through `Adapter.fetchRawData`.** The per-attempt timeout is currently _soft_ —
   it races the attempt against a timer and abandons the loser rather than cancelling it, because no

--- a/adapters/aquarius/types.ts
+++ b/adapters/aquarius/types.ts
@@ -137,8 +137,10 @@ export interface AquariusPool {
  * and the indexer's answer is a hard number: `cycleFeasibility()` allows
  * `ceil(targets / concurrency) * attemptTimeoutMs <= budgetMs`, and at
  * concurrency 1, a 10s attempt timeout and a budget that must stay inside
- * Vercel Hobby's 60s `maxDuration`, that ceiling is **five targets**. Four are
- * lending. So the ceiling on this list is deployment capacity, not the census.
+ * Vercel Hobby's 60s `maxDuration`, that ceiling is **five targets per
+ * invocation** — five in total until a second shard is provisioned, since
+ * sharding multiplies it by the number of cron jobs. Four are lending. So the
+ * ceiling on this list is deployment capacity, not the census.
  *
  * The census is real and was re-read for this decision at ledger 64,182,824 on
  * 2026-08-29: 340 pools across 304 token sets, 272 constant_product / 42 stable
@@ -220,10 +222,16 @@ export const AQUARIUS_XLM_USDC: AquariusPool = {
  * as `BLEND_POOLS` is, so registering a market is one entry here and nothing in
  * the indexer.
  *
- * ONE ENTRY IS NOT A PLACEHOLDER — it is the target budget, spent. Adding a
- * second requires a deployed per-target `durationMs` for this one and then a
- * LOWERED `STENION_ATTEMPT_TIMEOUT_MS`, not a raised budget: the budget is
- * already at 50s against a 60s hard ceiling. See `architecture/deploy-architecture.md`.
+ * ONE ENTRY IS NOT A PLACEHOLDER — it is the target budget, spent. What that
+ * budget IS changed on 2026-08-30: the five-target ceiling is per serverless
+ * invocation, and sharding splits the registry across several, so a second entry
+ * needs a shard with a free slot rather than a lowered
+ * `STENION_ATTEMPT_TIMEOUT_MS`. Provisioning that shard is a cron-job.org job,
+ * not a code change — see `architecture/deploy-architecture.md`.
+ *
+ * The deployed `durationMs` this comment used to ask for has been taken, and it
+ * is 1.5-1.6s: this pool is the FASTEST target in the registry, not the slowest,
+ * against an estimate of 5.5-8.7s built from its request count.
  */
 export const AQUARIUS_POOLS: readonly AquariusPool[] = [AQUARIUS_XLM_USDC];
 

--- a/architecture/deploy-architecture.md
+++ b/architecture/deploy-architecture.md
@@ -21,6 +21,11 @@ separate services. Everything runs from the single Next.js app:
   every 5 minutes with `Authorization: Bearer <CRON_SECRET>`. The route itself is stateless about
   cadence: it runs exactly one cycle per request, so the interval is entirely the caller's.
 
+  **One job per shard.** `POST /api/cron/run-indexer?shard=<i>&totalShards=<n>` scores only the
+  targets belonging to shard `i`; with no parameters it scores the whole registry, which is what
+  the single job configured today does. See "Sharding the registry across invocations" below for
+  the job table and the staggering rule.
+
   **The schedule is not in version control.** It lives in the cron-job.org dashboard — there is no
   workflow file, no `vercel.json` `crons` entry, and no other scheduling config in this repo.
   Changing the cadence, pausing indexing, or rotating the target URL is done in that service's UI,
@@ -199,7 +204,10 @@ before a single token is looked at. The adapter already caches accounts by addre
 of one fetch, which is what stops the router's roles and the pool's roles being read twice; without
 it the figure would be 28.
 
-> **The registry's ceiling is the deploy, not the census — and it is five targets.**
+> **The registry's ceiling is the deploy, not the census — and it is five targets per invocation.**
+> (Written before sharding existed, when one invocation WAS the registry. The arithmetic below is
+> unchanged and still governs one shard; what it no longer bounds is the registry as a whole — see
+> "Sharding the registry across invocations".)
 > `cycleFeasibility()` checks `ceil(targets / concurrency) * ATTEMPT_TIMEOUT_MS <= CYCLE_BUDGET_MS`.
 > At concurrency **1** and `ATTEMPT_TIMEOUT_MS` 10,000, the old 42,000ms budget allowed exactly
 > **four** targets — the four lending markets that were already registered — so registering **any**
@@ -247,23 +255,166 @@ it the figure would be 28.
 > The ceiling is still load-bearing and still respected; what changed is that there are now
 > measurements to size against, which is exactly what the previous comment on this default asked for.
 >
-> **This is the last target the budget can buy.** A sixth needs 60,000ms of attempts, which **is**
-> the `maxDuration` ceiling — so it cannot come from here. It has to come from a lower attempt
-> timeout justified by a deployed Aquarius `durationMs`, or from concurrency with its own measured
-> RPC-tolerance test. Which is why `AQUARIUS_POOLS` holds one entry while 339 further Aquarius pools
-> are scorable, and why those 339 are published on the registry under `coverage.ts`'s
-> `awaiting-capacity` status rather than being quietly omitted.
+> **This is the last target the budget can buy — _per invocation_.** A sixth needs 60,000ms of
+> attempts, which **is** the `maxDuration` ceiling, so it cannot come from the budget. It now
+> comes from **sharding**: the ceiling is five targets in ONE invocation, and `n` invocations carry
+> `5n`. See "Sharding the registry across invocations" below. A lower attempt timeout and a higher
+> concurrency remain the two ways to raise the _per-shard_ five, and both still need their own
+> deployed measurement.
 
 **Wall-clock from a developer machine is recorded but is NOT the claim.** A full local cycle on
 2026-08-29 ran all five targets in 36.7s — `etherfuse` 7,524ms, `aquarius-xlm-usdc` 8,929ms,
 `kinetic` 7,659ms, `yieldblox` 7,042ms, `blend` 5,545ms — from Nigeria against the public endpoint,
 which is exactly the measurement CLAUDE.md forbids making an RPC-load claim from. The _ratio_ is the
 usable part: Aquarius is ~1.6x Blend on the same machine in the same session, and Blend is 5,545ms
-locally against 2,412–3,049ms deployed. **A deployed per-target `durationMs` for `aquarius-xlm-usdc`
-is still owed**, and is the first thing to read off the cron route's response after this ships —
-`curl -X POST … /api/cron/run-indexer` returns it. If it exceeds the 10,000ms attempt timeout, the
-target will retry and eventually record a failed run rather than silently mis-score, and the answer
-is to reduce the adapter's request count, not to raise the budget again.
+locally against 2,412–3,049ms deployed.
+
+#### The post-batching deployed reading, 2026-08-30
+
+**Every registered target now has a deployed `durationMs`, including `aquarius-xlm-usdc` — the one
+this section previously recorded as owed.** Three cycles `curl`ed from the production cron route,
+concurrency 1, all five targets, after the ledger-entry batching landed:
+
+| Run       | kinetic  | yieldblox | etherfuse | blend    | aquarius-xlm-usdc | `totalMs`  | HTTP wall  |
+| --------- | -------- | --------- | --------- | -------- | ----------------- | ---------- | ---------- |
+| 1         | 5,230ms  | 3,011ms   | 2,612ms   | 2,053ms  | 1,546ms           | 15,392ms   | 17.9s      |
+| 2         | 5,341ms  | 3,158ms   | 2,569ms   | 1,932ms  | 1,638ms           | 15,576ms   | 16.7s      |
+| 3         | 5,462ms  | 2,861ms   | 2,198ms   | 2,203ms  | 1,620ms           | 15,280ms   | 16.4s      |
+| **Range** | 5.2–5.5s | 2.9–3.2s  | 2.2–2.6s  | 1.9–2.2s | **1.5–1.6s**      | 15.3–15.6s | 16.4–17.9s |
+
+**Aquarius is the FASTEST target in the registry, at roughly a quarter of what it was estimated to
+cost.** The estimate above put an Aquarius attempt at 5.5–8.7s, derived from its 37-request count
+against an observed 150–235ms per request — and that estimate is what justified _not_ lowering
+`STENION_ATTEMPT_TIMEOUT_MS` to buy the fifth target. The real figure is 1.5–1.6s. Two things it
+got wrong: batching collapsed the per-key `getLedgerEntries` reads (28 calls per cycle to 9), and
+requests inside one attempt are not serialized at the modelled rate. **The lesson is symmetric with
+the concurrency incident, pointing the other way** — a request count is machine-independent and a
+duration is not, so neither substitutes for the deployed reading.
+
+**Batching absorbed the entire fifth target.** Against the 2026-08-29 four-target cycles
+(`totalMs` 15,482 / 15,627 / 16,759), the five-target post-batching cycles run in 15,280–15,576ms:
+one more target, same wall clock. Per-target it is a 15–25% reduction across the lending adapters
+(yieldblox 3.7–3.9s → 2.9–3.2s, etherfuse 3.0–3.2s → 2.2–2.6s, blend 2.4–3.0s → 1.9–2.2s), with
+kinetic flat at 5.2–5.5s — it reads 27 RPC calls and almost none of them were ledger-entry reads.
+
+**This does not raise the five-target ceiling, and it is important to say why.** `cycleFeasibility`
+is sized on `STENION_ATTEMPT_TIMEOUT_MS`, not on measured durations: it asks whether every target
+could get one _full_ attempt if it needed one, which is a worst-case guarantee and not a throughput
+estimate. Faster targets would justify **lowering the attempt timeout**, which is the dial that
+would raise the ceiling — and the headroom is thinner than the durations suggest, because
+`DEFAULT_RATE_LIMIT_POLICY` lets one attempt spend up to 2,000ms waiting out `429`s _inside_ that
+cap. The slowest healthy attempt is kinetic at 5.5s, so 5.5 + 2.0 = 7.5s must fit; at the current
+10,000ms that leaves 2.5s of margin, and at 8,400ms it would leave 0.9s. **Not lowered here** —
+that is its own flagged decision with its own measurement, and sharding made it unnecessary.
+
+**`SLOWEST_FIRST` in `indexer/src/cycle.ts` tracks this table** and was updated with it. Two targets
+(`etherfuse`, `aquarius-xlm-usdc`) had been absent from that list and were therefore ordered as
+assumed-slowest; both are now placed by measurement, and `aquarius-xlm-usdc` sorts **last**. At
+concurrency 1 the ordering cannot change a cycle's makespan — the sum is the sum — but it decides
+the makespan the moment concurrency rises.
+
+### Sharding the registry across invocations
+
+**The problem this solves.** `cycleFeasibility()` requires every registered target to get one full
+attempt inside the cycle budget — `ceil(targets / concurrency) * ATTEMPT_TIMEOUT_MS <= BUDGET_MS`.
+At the shipped defaults that is **five targets per invocation**, and all three dials behind it are
+pinned by something measured (see the table above). The sixth target could not come from a dial, so
+it comes from running **more than one invocation**.
+
+`POST /api/cron/run-indexer?shard=<i>&totalShards=<n>` scores only shard `i`. Both parameters are
+optional and **both-or-neither**: sending neither scores the whole registry, so the job that existed
+before sharding keeps working untouched. A half-configured job (`?shard=1` alone) and a job that
+could never match anything (`?shard=2&totalShards=2`) are both **400s**, not quiet no-ops — a shard
+spec that silently scores nothing would return a cheerful `ran: 0` forever while a slice of the
+registry went stale.
+
+**How a target is assigned.** `selectShard` (in `indexer/src/cycle.ts`) sorts every target by
+`(FNV-1a hash of its id, id)` and deals that order round-robin across the shards. Two properties
+matter and both are tested:
+
+- **Balanced to within one target, always.** That is what makes `n` shards worth `5n` slots. The
+  simpler `hash(id) % totalShards` was measured against this registry and rejected: today's five
+  slugs land **4 and 1** across two shards, so the second invocation would buy four slots instead
+  of five, and at ten targets a two-way split is more likely than not to put six in one shard and
+  be infeasible outright.
+- **Independent of input order.** The deal is sorted by hash, so re-measuring a target and changing
+  `SLOWEST_FIRST` cannot reshuffle the shards. `selectShard` also preserves the order of the list
+  it is handed, so a shard of a slowest-first registry is still slowest-first — ordering and
+  sharding compose without either knowing the other ran.
+
+**What it costs, stated plainly:** registering a sixth target can move an existing target to a
+different shard. That is safe here, and the reason is specific rather than general — **nothing in
+this system is keyed by shard.** A run record is keyed by protocol; a failure streak is _derived_
+by `decideAlert` from that protocol's own `risk_scores` rows rather than counted in a per-cycle
+counter; staleness is per protocol. A target that changes shard is scored a few minutes earlier or
+later and nothing observes the move. `cycle.test.ts` pins it: the same target reaches a
+byte-identical alert decision sharded and unsharded. **If some future state is ever keyed by shard,
+this is the decision to revisit.**
+
+#### Deploy config: the cron-job.org jobs
+
+**`n` shards means `n` jobs**, each every 5 minutes, each hitting the same URL with its own
+`shard`. All of them carry the same `Authorization: Bearer <CRON_SECRET>` header and the same
+`POST` method as the single job does today. This is infra config in the cron-job.org dashboard —
+**not in this repo** — so this table is the only place the mapping is written down.
+
+| Shards | Jobs | URL each job POSTs                                                                  | Minutes each job fires                 |
+| ------ | ---- | ----------------------------------------------------------------------------------- | -------------------------------------- |
+| 1      | 1    | `/api/cron/run-indexer` (no parameters)                                             | `0,5,10,…`                             |
+| 2      | 2    | `…?shard=0&totalShards=2`<br>`…?shard=1&totalShards=2`                              | `0,5,10,…`<br>`1,6,11,…`               |
+| 3      | 3    | `…?shard=0&totalShards=3`<br>`…?shard=1&totalShards=3`<br>`…?shard=2&totalShards=3` | `0,5,10,…`<br>`1,6,11,…`<br>`2,7,12,…` |
+
+**The jobs must be STAGGERED, not simultaneous, and this is load-bearing rather than tidy.**
+`STENION_CYCLE_CONCURRENCY` bounds parallel targets _within_ one invocation and has no idea another
+invocation exists. Two shards fired on the same minute put two request streams on
+`mainnet.sorobanrpc.com` and reproduce the concurrency-2 `429` incident from a direction the config
+cannot see or prevent. A cycle is ~16s, so a one-minute offset is ample.
+
+**Freshness is unchanged, and that is the point of using `n` jobs rather than one rotating job.**
+Each shard runs every 5 minutes, so every target is still scored every 5 minutes —
+`STENION_HEALTH_STALE_MINUTES` (30) and `STENION_ALERT_THRESHOLD` (4 cycles ≈ 20 min) keep their
+meanings with nothing to retune. ROADMAP.md previously costed sharding as "a five-minute cadence
+over three shards is a fifteen-minute worst case per market"; that is the cost of the _rotating
+single job_ shape, and it is not the shape that shipped.
+
+**Alerting becomes one POST per shard invocation**, where it was one per cycle. Each shard batches
+its own targets' alerts into a single webhook POST, so an RPC-wide outage that takes out the whole
+registry now reads as `n` messages covering disjoint sets rather than one covering everything.
+That was weighed and accepted: streak state is per protocol and cannot double-count or reset (see
+above), and the split actually _helps_ the `MAX_MESSAGE_CHARS` truncation problem `alerts.ts`
+documents, because each message carries fewer alerts.
+
+**When `totalShards` changes, every target may move.** That is inherent to any modular assignment
+and is a deliberate infra change, not something that happens on a code deploy. Nothing breaks — the
+next cycle scores the same registry through a different split.
+
+#### Verifying a sharded rotation after deploy
+
+Coverage is the thing to check, and it is checkable: run every shard by hand and confirm the union
+of what they scored is the registry, with nothing scored twice.
+
+```bash
+# 2 shards. Each call returns `shard`, `totalShards` and the per-target `durationMs`.
+for i in 0 1; do
+  curl -s -X POST -H "Authorization: Bearer $CRON_SECRET" \
+    "https://stenion.vercel.app/api/cron/run-indexer?shard=$i&totalShards=2"
+  echo
+done
+```
+
+Three things to read off the responses:
+
+1. **Coverage** — the `results[].id` values across all shards must be the five registered targets,
+   each appearing exactly once. Zero occurrences means a target is going stale; two means it is
+   writing two rows a cycle and will cross the alert threshold in half the intended time.
+2. **`totalMs` per shard**, comfortably under `STENION_CYCLE_BUDGET_MS` (50,000). A shard of 2–3
+   targets should land near 6–10s given the per-target durations above.
+3. **A 400 on a bad spec** — `?shard=2&totalShards=2` must be refused rather than returning
+   `ran: 0`.
+
+Run the shards **sequentially**, as above, not in parallel: firing them together is the same
+mistake the staggering rule exists to prevent, and it will show up as `429`s rather than as
+anything about sharding.
 
 ### Caching and rate limits
 

--- a/architecture/monorepo-layout.md
+++ b/architecture/monorepo-layout.md
@@ -392,13 +392,16 @@ still recorded as `failed` — a protocol that is genuinely down still shows as 
   ceil(targetCount / STENION_CYCLE_CONCURRENCY) * STENION_ATTEMPT_TIMEOUT_MS <= STENION_CYCLE_BUDGET_MS
   ```
 
-  At the shipped defaults (50s budget, 10s attempt, concurrency 1) that holds to **five targets** and
-  fails at six — and six cannot be bought with a bigger budget, because six attempts need the whole
-  60s `maxDuration`. `cycleFeasibility()`
+  At the shipped defaults (50s budget, 10s attempt, concurrency 1) that holds to **five targets per
+  invocation** and fails at six — and six cannot be bought with a bigger budget, because six attempts
+  need the whole 60s `maxDuration`. It is bought instead by **sharding**: `runCycle` only ever sees
+  one shard's targets, so this condition is evaluated against that subset and `n` shards carry
+  `5n` targets (see `selectShard`, and the job table in
+  [`deploy-architecture.md`](deploy-architecture.md)). `cycleFeasibility()`
   checks it every cycle and at indexer startup, and logs a `[budget]` warning naming the numbers and
-  the levers (raise concurrency, lower the attempt timeout, or shard). It **warns and runs** rather
-  than refusing — taking the whole registry down because someone registered a fifth pool is worse
-  than running five protocols imperfectly and saying so. Past the ceiling it degrades to whole
+  the levers (raise concurrency, lower the attempt timeout, or add a shard). It **warns and runs**
+  rather than refusing — taking the whole registry down because someone registered a fifth pool is
+  worse than running five protocols imperfectly and saying so. Past the ceiling it degrades to whole
   attempts on a first-come basis with the tail failing cleanly (`DeadlineExceededError`) and going
   visibly stale on `/api/v1/health`, rather than squeezing every target into a length at which none
   of them can succeed.

--- a/dashboard/app/api/cron/run-indexer/route.ts
+++ b/dashboard/app/api/cron/run-indexer/route.ts
@@ -1,4 +1,5 @@
-// POST /api/cron/run-indexer — trigger ONE indexer cycle.
+// POST /api/cron/run-indexer[?shard=<i>&totalShards=<n>] — trigger ONE indexer cycle
+// over ONE shard of the registry.
 //
 // The indexer is NOT a long-running deployed process on Vercel (serverless has no
 // always-on scheduler, and Hobby-tier Vercel Cron is capped at once-per-day). Instead
@@ -11,6 +12,22 @@
 // no workflow file, vercel.json `crons` entry, or any other scheduling config to find in
 // version control — changing the cadence means logging into that service.
 //
+// SHARDING. `?shard=i&totalShards=n` scores only the targets belonging to shard `i`, so a
+// registry too big for one 60s invocation is covered by `n` jobs instead of one. Both
+// parameters are optional and BOTH-OR-NEITHER: omitting them scores the whole registry,
+// which is exactly what this route did before sharding existed, so the job already
+// configured keeps working untouched. Which target lands in which shard is decided by
+// `selectShard` in @stenion/indexer, from the target ids alone — not here, and not by
+// anything in this route's configuration.
+//
+// THE n JOBS MUST BE STAGGERED, NOT SIMULTANEOUS, and that is a load-bearing detail
+// rather than a preference: `STENION_CYCLE_CONCURRENCY` bounds parallel targets WITHIN one
+// invocation and has no idea another invocation exists, so two shards fired at the same
+// minute put two request streams on the shared public RPC and reproduce the concurrency-2
+// incident from a direction the config cannot see. Offset the jobs by a minute or more —
+// a cycle is ~16s — and peak in-flight stays at one. The mapping and the offsets are
+// written down in architecture/deploy-architecture.md.
+//
 // PROTECTION: this endpoint writes to the DB and hits RPC/Horizon, so it must not be
 // publicly spam-triggerable. It requires `Authorization: Bearer <CRON_SECRET>`,
 // compared in constant time. If CRON_SECRET is not configured, the route refuses to
@@ -18,11 +35,12 @@
 
 import { timingSafeEqual } from 'node:crypto';
 import { loadEnv } from '@stenion/db';
-import { runIndexerCycle } from '@stenion/indexer';
+import { resolveShardSpec, runIndexerCycle } from '@stenion/indexer';
 
-// pg + Soroban/Horizon I/O need the Node.js runtime. A full cycle (5 targets —
+// pg + Soroban/Horizon I/O need the Node.js runtime. A full unsharded cycle (5 targets —
 // three Blend pools, Kinetic, and one Aquarius pool) makes several on-chain sim
 // calls each, so allow up to 60s (Vercel Hobby max) rather than the 10s default.
+// A sharded invocation runs a subset and finishes well inside that.
 // The cycle's own wall-clock budget (STENION_CYCLE_BUDGET_MS, 50s) is what keeps
 // it inside this ceiling; see architecture/ on why a budget rather than a fixed
 // schedule, and why 50s is the last value that fits under 60.
@@ -62,10 +80,28 @@ export async function POST(req: Request): Promise<Response> {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Parsed AFTER the auth check, so an unauthenticated caller learns nothing about
+  // the parameters this route takes. The rule it enforces (0 <= shard < totalShards)
+  // is what guarantees a full rotation covers every target exactly once; it lives in
+  // @stenion/indexer because a route handler is not something this repo can load from
+  // a test.
+  const url = new URL(req.url);
+  const parsed = resolveShardSpec(
+    url.searchParams.get('shard'),
+    url.searchParams.get('totalShards'),
+  );
+  if (!parsed.ok) {
+    return Response.json({ error: parsed.error }, { status: 400 });
+  }
+  const { shard, totalShards } = parsed.spec;
+
   try {
-    const summary = await runIndexerCycle();
+    const summary = await runIndexerCycle(parsed.spec);
     // `triggered` (not `ok`) so it doesn't collide with the summary's ok-count.
-    return Response.json({ triggered: true, ...summary });
+    // `shard`/`totalShards` are echoed back because verifying coverage means
+    // checking that the union of what the shards ran is the whole registry, and a
+    // summary that doesn't say which shard produced it cannot be checked that way.
+    return Response.json({ triggered: true, shard, totalShards, ...summary });
   } catch (err) {
     // Bad env / unreachable DB throws here; per-protocol scoring errors do NOT
     // (they're captured in the summary). Log the raw error, return a generic 500.

--- a/dashboard/app/lib/coverage.ts
+++ b/dashboard/app/lib/coverage.ts
@@ -132,7 +132,9 @@ export type CoverageStatus =
    * rulebook applies, the reads work, the number would be as true of these
    * markets as of the one that is scored — and a scoring cycle runs inside
    * Vercel Hobby's 60s `maxDuration`, which at the shipped attempt timeout and
-   * concurrency allows five targets in total.
+   * concurrency allows five targets per invocation. Sharding splits the registry
+   * across several invocations, so the number is `5 x the shards provisioned`;
+   * the shards beyond the first are cron jobs nobody has created yet.
    *
    * Deliberately NOT folded into `below-size-floor`, which would be a lie twice
    * over: `dex` has no size floor (methodology/dex.md, "Size floor: none, and
@@ -144,11 +146,15 @@ export type CoverageStatus =
    * imply a finding about the markets it lists.
    *
    * THE WAY OUT IS TRACKED IN ROADMAP.md, not here. All three scheduling dials
-   * are at their limits (budget at 50s against a 60s hard ceiling, concurrency
-   * pinned at 1 by the RPC 429 incident, attempt timeout already lowered once),
-   * so nothing can be registered — of any category — until sharding or staggered
-   * scheduling lands. This status is what that looks like from the registry;
-   * ROADMAP.md's blocker is what it looks like as work.
+   * are still at their limits (budget at 50s against a 60s hard ceiling,
+   * concurrency pinned at 1 by the RPC 429 incident, attempt timeout already
+   * lowered once) — but the ceiling those dials set is now PER INVOCATION rather
+   * than per registry: sharding has shipped, so capacity is bought by running
+   * more cron jobs instead of by moving a dial. Nothing further is registered
+   * yet because those jobs are infra config outside this repo, which is why this
+   * status still has members. It is now "no slot has been provisioned" rather
+   * than "no slot can exist". This status is what that looks like from the
+   * registry; ROADMAP.md is what it looks like as work.
    */
   | 'awaiting-capacity';
 

--- a/indexer/src/cycle.test.ts
+++ b/indexer/src/cycle.test.ts
@@ -17,15 +17,20 @@ import { beforeEach, describe, it } from 'node:test';
 
 import {
   DEFAULT_CONCURRENCY,
+  SINGLE_SHARD,
   cycleFeasibility,
   cycleWaves,
   feasibilityWarning,
   orderByLatency,
+  resolveShardSpec,
   runCycle,
+  selectShard,
   targetDeadline,
+  targetHash,
   toTarget,
   type CycleOptions,
   type IndexTarget,
+  type ShardSpec,
 } from './cycle.ts';
 import type { StreakAlert } from './alerts.ts';
 import {
@@ -1038,9 +1043,25 @@ describe('orderByLatency — slowest first, because the pool overlaps the rest',
   it('puts the slowest measured target first and the fastest last', () => {
     // The order the indexer actually registers them in is BLEND_POOLS order
     // (blend, yieldblox) then kinetic. Deployed-function durations put Kinetic
-    // slowest and Blend Fixed fastest — see ARCHITECTURE.md.
+    // slowest and Blend Fixed fastest — see architecture/deploy-architecture.md.
     const ordered = orderByLatency(['blend', 'yieldblox', 'kinetic'].map((id) => okTarget(id)));
     assert.deepEqual(ids(ordered), ['kinetic', 'yieldblox', 'blend']);
+  });
+
+  it('orders the whole live registry by its deployed durations', () => {
+    // Pinned against the 2026-08-30 post-batching reading, so a change to
+    // SLOWEST_FIRST that contradicts the measurement fails here rather than in
+    // a comment nobody re-reads. aquarius-xlm-usdc is LAST — it is the fastest
+    // target in the registry, which is the opposite of what its request count
+    // predicted.
+    const registry = ['blend', 'yieldblox', 'etherfuse', 'kinetic', 'aquarius-xlm-usdc'];
+    assert.deepEqual(ids(orderByLatency(registry.map((id) => okTarget(id)))), [
+      'kinetic',
+      'yieldblox',
+      'etherfuse',
+      'blend',
+      'aquarius-xlm-usdc',
+    ]);
   });
 
   it('is the OPPOSITE of the order it replaced, and that is the point', () => {
@@ -1056,10 +1077,15 @@ describe('orderByLatency — slowest first, because the pool overlaps the rest',
   it('treats an unmeasured target as the slowest, so a new pool is not squeezed', () => {
     // A pool registered in BLEND_POOLS that nobody has timed yet must not land
     // in the worst slot by default. Assumed-slowest is the conservative reading.
+    //
+    // The stand-in used to be 'etherfuse', which stopped being unmeasured on
+    // 2026-08-30 when every registered target got a deployed durationMs. The
+    // rule under test is unchanged; only the example had to be one the registry
+    // genuinely does not know.
     const ordered = orderByLatency(
-      ['blend', 'etherfuse', 'kinetic', 'yieldblox'].map((id) => okTarget(id)),
+      ['blend', 'brand-new-pool', 'kinetic', 'yieldblox'].map((id) => okTarget(id)),
     );
-    assert.equal(ids(ordered)[0], 'etherfuse');
+    assert.equal(ids(ordered)[0], 'brand-new-pool');
   });
 
   it('keeps registration order between equally-ranked targets', () => {
@@ -1722,5 +1748,317 @@ describe('retries in one target do not touch another target', () => {
       budget.endsAt <= startedAt + 10_000 + 50,
       'the budget must expire with the attempt, not with the cycle',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sharding
+// ---------------------------------------------------------------------------
+
+/** The five targets registered today, in the order buildTargets assembles them. */
+const REGISTRY = ['blend', 'yieldblox', 'etherfuse', 'kinetic', 'aquarius-xlm-usdc'];
+
+const shardIds = (ids: string[], spec: ShardSpec): string[] =>
+  selectShard(
+    ids.map((id) => okTarget(id)),
+    spec,
+  ).map((t) => t.metadata.id);
+
+/** Every shard of a split, as arrays of ids. */
+function allShards(ids: string[], totalShards: number): string[][] {
+  return Array.from({ length: totalShards }, (_, shard) => shardIds(ids, { shard, totalShards }));
+}
+
+describe('selectShard — deterministic, balanced, exactly-once', () => {
+  it('is deterministic: the same list splits the same way every time', () => {
+    // The property the whole scheme rests on. Two cron jobs are separate
+    // processes on separate invocations and share no state, so if this were not
+    // a pure function of the ids they could both run a target, or neither.
+    for (const totalShards of [2, 3, 4]) {
+      assert.deepEqual(allShards(REGISTRY, totalShards), allShards(REGISTRY, totalShards));
+    }
+  });
+
+  it('does not depend on the order the targets arrive in', () => {
+    // orderByLatency runs before the split, and SLOWEST_FIRST changes whenever
+    // someone re-measures. If membership tracked input order, re-measuring a
+    // target would silently reshuffle the shards.
+    const reversed = [...REGISTRY].reverse();
+    for (const totalShards of [2, 3]) {
+      for (let shard = 0; shard < totalShards; shard++) {
+        const a = new Set(shardIds(REGISTRY, { shard, totalShards }));
+        const b = new Set(shardIds(reversed, { shard, totalShards }));
+        assert.deepEqual([...a].sort(), [...b].sort());
+      }
+    }
+  });
+
+  it('covers every target exactly once across a full rotation', () => {
+    // Not zero and not twice — the acceptance property. A target scored by two
+    // shards writes two rows per cycle and doubles its own history; one scored
+    // by none goes stale with nothing saying why.
+    for (const totalShards of [1, 2, 3, 4, 5, 6]) {
+      const seen = allShards(REGISTRY, totalShards).flat();
+      assert.equal(seen.length, REGISTRY.length, `totalShards=${totalShards} ran ${seen.length}`);
+      assert.deepEqual([...seen].sort(), [...REGISTRY].sort());
+    }
+  });
+
+  it('balances to within one target, which is what buys the capacity', () => {
+    // The reason a balanced deal was chosen over `hash % totalShards`. The
+    // registry ceiling is per shard, so N shards are worth N x the ceiling only
+    // if the split is even; the hash-mod alternative puts 4 of today's 5 slugs
+    // in one shard and would buy four slots instead of five.
+    for (const totalShards of [2, 3, 4]) {
+      const sizes = allShards(REGISTRY, totalShards).map((s) => s.length);
+      assert.ok(
+        Math.max(...sizes) - Math.min(...sizes) <= 1,
+        `totalShards=${totalShards} produced sizes ${sizes.join('/')}`,
+      );
+    }
+  });
+
+  it('grows in balance rather than in membership, and that is the tradeoff', () => {
+    // THE DECISION, PINNED. A balanced deal cannot also be stable under growth,
+    // and this asserts which half was chosen: adding a sixth target keeps every
+    // shard within one of the others, and MAY move an existing target. It is
+    // safe because nothing is keyed by shard — the suite below proves that
+    // rather than assuming it. If this ever needs to become "membership never
+    // moves", the fix is a different algorithm, not a relaxed assertion.
+    const grown = [...REGISTRY, 'aquarius-xlm-eurc'];
+    const sizes = allShards(grown, 2).map((s) => s.length);
+    assert.deepEqual(sizes, [3, 3]);
+    const seen = allShards(grown, 2).flat();
+    assert.deepEqual([...seen].sort(), [...grown].sort());
+  });
+
+  it('returns the whole registry at totalShards 1, untouched in order', () => {
+    // The default, and the old behaviour: the cron job that exists today passes
+    // no parameters and must keep scoring everything, in latency order.
+    assert.deepEqual(shardIds(REGISTRY, SINGLE_SHARD), REGISTRY);
+  });
+
+  it('preserves the input order inside a shard, so orderByLatency survives', () => {
+    // The split filters; it does not re-sort. A shard of a slowest-first list is
+    // still slowest-first, so the ordering heuristic keeps applying to the
+    // subset each invocation actually runs.
+    const ordered = orderByLatency(REGISTRY.map((id) => okTarget(id))).map((t) => t.metadata.id);
+    for (let shard = 0; shard < 3; shard++) {
+      const mine = shardIds(ordered, { shard, totalShards: 3 });
+      assert.deepEqual(
+        mine,
+        ordered.filter((id) => mine.includes(id)),
+      );
+    }
+  });
+
+  it('does not mutate the list it was given', () => {
+    const targets = REGISTRY.map((id) => okTarget(id));
+    selectShard(targets, { shard: 0, totalShards: 2 });
+    assert.deepEqual(
+      targets.map((t) => t.metadata.id),
+      REGISTRY,
+    );
+  });
+
+  it('hashes ids to a stable 32-bit value', () => {
+    // Pinned so a "harmless" rewrite of targetHash is caught here rather than by
+    // a shard rotation that quietly re-partitions the registry mid-deploy.
+    assert.equal(targetHash(''), 0x811c9dc5);
+    assert.equal(targetHash('blend'), targetHash('blend'));
+    assert.notEqual(targetHash('blend'), targetHash('kinetic'));
+    for (const id of REGISTRY) {
+      const h = targetHash(id);
+      assert.ok(Number.isInteger(h) && h >= 0 && h <= 0xffffffff, `${id} hashed to ${h}`);
+    }
+  });
+});
+
+describe('cycleFeasibility — checked against a shard, not the registry', () => {
+  it('is evaluated per shard, so a split registry is feasible where the whole is not', () => {
+    // The point of the change. Six targets at the shipped defaults need 60,000ms
+    // of attempts, which IS Vercel Hobby's maxDuration — infeasible in one
+    // invocation. Split across two shards, each invocation checks 3.
+    const shipped = { concurrency: 1, attemptTimeoutMs: 10_000, budgetMs: 50_000 };
+    assert.equal(cycleFeasibility({ targetCount: 6, ...shipped }).feasible, false);
+    for (const size of [3, 3]) {
+      assert.equal(cycleFeasibility({ targetCount: size, ...shipped }).feasible, true);
+    }
+  });
+
+  it('checks each shard against its own size, not the global count', () => {
+    // An uneven split (3 and 2) is two independent questions, and the smaller
+    // shard must not inherit the larger one's requirement.
+    const shipped = { concurrency: 1, attemptTimeoutMs: 10_000, budgetMs: 50_000 };
+    assert.equal(cycleFeasibility({ targetCount: 3, ...shipped }).requiredMs, 30_000);
+    assert.equal(cycleFeasibility({ targetCount: 2, ...shipped }).requiredMs, 20_000);
+  });
+
+  it('runCycle warns about the shard it was handed, not the registry behind it', async () => {
+    // runCycle only ever sees this shard's targets, so its feasibility warning
+    // is per-shard for free — but "for free" is exactly the kind of claim that
+    // stops being true silently, so it is asserted.
+    const { store } = fakeStore();
+    const shard = ['a', 'b'].map((id) => okTarget(id));
+    await runCycle(shard, store, {
+      retry: { attempts: 1, baseDelayMs: 0, attemptTimeoutMs: 10_000 },
+      budgetMs: 50_000,
+    });
+    assert.equal(
+      logs.some((l) => l.includes('[budget]')),
+      false,
+      'two targets inside a 50s budget must not warn',
+    );
+  });
+});
+
+describe('sharding cannot reset or double-count an alert streak', () => {
+  // THE DECISION THIS PROVES. checkStreak reads a protocol's own risk_scores
+  // rows and derives the streak from them (alerts.ts, "WHY DERIVE"). Nothing is
+  // keyed by the cycle or by the shard, so a target moved between shards keeps
+  // its history — and a target scored in a shard reaches the identical alert
+  // decision it would have reached unsharded. That is what makes the balanced
+  // deal's reshuffling safe, and it is asserted rather than reasoned about.
+
+  /** Run one target under a given shard spec against a seeded history. */
+  async function runUnder(spec: ShardSpec, history: Record<string, RecentRun[]>) {
+    const { store, written } = fakeStore({ history });
+    const { notifier, all } = fakeNotifier();
+    const registry = REGISTRY.map((id) => throwingTarget(id));
+    await runCycle(selectShard(registry, spec), store, alerting({ notifier }));
+    return { alerts: all(), written };
+  }
+
+  it('reaches the same alert decision sharded as unsharded', async () => {
+    // kinetic arrives with three consecutive failures; this cycle's own failure
+    // is the fourth and crosses STENION_ALERT_THRESHOLD. The alert must fire
+    // once, identically, whichever way the registry was split.
+    const history = { kinetic: failedRuns(3) };
+
+    const whole = await runUnder(SINGLE_SHARD, history);
+    const kineticAlert = whole.alerts.find((a) => a.protocolId === 'kinetic');
+    assert.ok(kineticAlert, 'unsharded: kinetic crosses the threshold');
+    assert.equal(kineticAlert.kind, 'failing');
+    assert.equal(kineticAlert.consecutiveFailures, 4);
+
+    // Find the shard kinetic actually lands in, for every split, and run it.
+    //
+    // Compared field by field except `lastFailureAt`, which is THIS cycle's own
+    // runAt and so differs by a millisecond between any two runs, sharded or
+    // not. It is a clock reading, not part of the decision; everything that
+    // decides whether and what to alert is asserted identical.
+    const decision = ({ lastFailureAt: _ignored, ...rest }: StreakAlert) => rest;
+    for (const totalShards of [2, 3]) {
+      const shard = allShards(REGISTRY, totalShards).findIndex((s) => s.includes('kinetic'));
+      const sharded = await runUnder({ shard, totalShards }, history);
+      const same = sharded.alerts.find((a) => a.protocolId === 'kinetic');
+      assert.ok(same, `totalShards=${totalShards}: kinetic still alerts`);
+      assert.deepEqual(
+        decision(same),
+        decision(kineticAlert),
+        `totalShards=${totalShards}: identical alert decision`,
+      );
+    }
+  });
+
+  it('writes exactly one run record per target per rotation', () => {
+    // Double-counting is the other half of the risk: a target in two shards
+    // would append two failed rows per cycle and cross the threshold in half
+    // the time. Exactly-once membership is what forbids it.
+    for (const totalShards of [2, 3]) {
+      const dealt = allShards(REGISTRY, totalShards).flat();
+      const counts = new Map<string, number>();
+      for (const id of dealt) counts.set(id, (counts.get(id) ?? 0) + 1);
+      for (const id of REGISTRY) {
+        assert.equal(counts.get(id), 1, `${id} appears ${counts.get(id)} times`);
+      }
+    }
+  });
+
+  it('a shard that alerts posts its own batch, covering only its own targets', async () => {
+    // THE ACCEPTED COST, pinned so it is a decision rather than a surprise. One
+    // POST per cycle becomes one POST per shard invocation: an RPC-wide outage
+    // that takes out the whole registry now reads as N messages rather than 1,
+    // each covering a disjoint set. Within a shard the batching is unchanged.
+    const history = Object.fromEntries(REGISTRY.map((id) => [id, failedRuns(3)]));
+    const totalShards = 2;
+    const seen: string[] = [];
+    for (let shard = 0; shard < totalShards; shard++) {
+      const { store } = fakeStore({ history });
+      const { notifier, batches } = fakeNotifier();
+      const registry = REGISTRY.map((id) => throwingTarget(id));
+      const mine = selectShard(registry, { shard, totalShards });
+      await runCycle(mine, store, alerting({ notifier }));
+
+      assert.equal(batches.length, 1, 'one POST per shard invocation, not one per target');
+      const alerted = batches[0].map((a) => a.protocolId).sort();
+      assert.deepEqual(
+        alerted,
+        mine.map((t) => t.metadata.id).sort(),
+        'a shard alerts about its own targets and no others',
+      );
+      seen.push(...alerted);
+    }
+    // Across the rotation every protocol is still alerted about exactly once.
+    assert.deepEqual(seen.sort(), [...REGISTRY].sort());
+  });
+
+  it('a fresh history still never alerts, sharded', async () => {
+    // The empty-table rule (alerts.ts) must survive the split: a protocol whose
+    // shard has just started running has no history, and 0 leading failures is
+    // not a streak.
+    const { alerts } = await runUnder({ shard: 0, totalShards: 2 }, {});
+    assert.deepEqual(alerts, []);
+  });
+});
+
+describe('resolveShardSpec — refuses anything that breaks coverage', () => {
+  const ok = (r: ReturnType<typeof resolveShardSpec>) => {
+    assert.equal(r.ok, true, r.ok ? '' : r.error);
+    return r.ok ? r.spec : SINGLE_SHARD;
+  };
+  const err = (r: ReturnType<typeof resolveShardSpec>) => {
+    assert.equal(r.ok, false, 'expected a refusal');
+    return r.ok ? '' : r.error;
+  };
+
+  it('defaults to the whole registry when neither parameter is given', () => {
+    // Backwards compatibility, and it is load-bearing: the cron-job.org job that
+    // exists today sends no query string and must keep scoring everything.
+    assert.deepEqual(ok(resolveShardSpec(null, null)), SINGLE_SHARD);
+    assert.deepEqual(ok(resolveShardSpec('', '  ')), SINGLE_SHARD);
+    assert.deepEqual(ok(resolveShardSpec(undefined, undefined)), SINGLE_SHARD);
+  });
+
+  it('accepts a well-formed spec', () => {
+    assert.deepEqual(ok(resolveShardSpec('0', '3')), { shard: 0, totalShards: 3 });
+    assert.deepEqual(ok(resolveShardSpec('2', '3')), { shard: 2, totalShards: 3 });
+  });
+
+  it('refuses one parameter without the other', () => {
+    // A half-configured job. Guessing the missing half means scoring a subset
+    // nobody asked for, which is worse than a 400 the operator can see.
+    assert.match(err(resolveShardSpec('1', null)), /together/);
+    assert.match(err(resolveShardSpec(null, '2')), /together/);
+  });
+
+  it('refuses a shard that is not less than totalShards', () => {
+    // The spec that silently scores nothing, forever, while a slice of the
+    // registry goes stale with a cheerful 200 on every invocation.
+    assert.match(err(resolveShardSpec('2', '2')), /less than/);
+    assert.match(err(resolveShardSpec('9', '3')), /less than/);
+  });
+
+  it('refuses totalShards below 1', () => {
+    assert.match(err(resolveShardSpec('0', '0')), /at least 1/);
+  });
+
+  it('refuses anything that is not a plain integer', () => {
+    // Number() would take all of these. A cron job's URL carries an integer or
+    // is told it does not.
+    for (const bad of ['1e0', '0x1', '1.5', '-1', 'two', ' ']) {
+      assert.equal(resolveShardSpec(bad, '4').ok, false, `accepted shard="${bad}"`);
+      assert.equal(resolveShardSpec('0', bad).ok, false, `accepted totalShards="${bad}"`);
+    }
   });
 });

--- a/indexer/src/cycle.ts
+++ b/indexer/src/cycle.ts
@@ -297,27 +297,43 @@ export function cycleWaves(queued: number, concurrency: number): number {
  * nothing can overlap with. Keeping the old order after removing the rule that
  * justified it would have been the quiet regression.
  *
- * Durations are the deployed-function measurements in ARCHITECTURE.md
- * (2026-08-25, five cycles): Kinetic 4.8-6.1s, YieldBlox 3.8-4.3s, Blend Fixed
- * 2.3-2.6s. Kinetic and YieldBlox swapped places when the measurement moved off
- * a developer machine and onto Vercel, which is the whole argument for measuring
- * there. At the three targets and concurrency 2 of that measurement the swap
- * changed nothing — those two shared wave 1 either way, and what matters is that
- * the fastest target is last — but a list whose comment cites numbers that no
- * longer hold is a list nobody can check, so it tracks the measurement.
+ * Durations are deployed-function measurements, never local ones. The current
+ * list is the 2026-08-30 reading (three cycles `curl`ed from the cron route,
+ * concurrency 1, all five targets), taken AFTER the ledger-entry batching
+ * landed:
  *
- * DELIBERATELY NOT UPDATED FOR ETHERFUSE. It has no deployed measurement,
- * so it is not on this list and `orderByLatency` therefore treats it as the
- * slowest and runs it first — the conservative default this list is built to
- * allow. Add it here only once the cron route's per-target `durationMs` says
- * where it belongs; guessing its rank from a local timing is the exact mistake
- * the concurrency incident was.
+ *   kinetic 5.2-5.5s · yieldblox 2.9-3.2s · etherfuse 2.2-2.6s ·
+ *   blend 1.9-2.2s · aquarius-xlm-usdc 1.5-1.6s
+ *
+ * EVERY REGISTERED TARGET IS NOW MEASURED, which is new: etherfuse and
+ * aquarius-xlm-usdc were both absent from this list, and `orderByLatency`
+ * therefore ran them first as assumed-slowest. That default did its job and is
+ * kept for the next unmeasured pool, but holding it for a target we now have
+ * numbers for would state the opposite of what was measured — aquarius-xlm-usdc
+ * is the FASTEST target in the registry, at roughly a quarter of the 5.5-8.7s
+ * its request count was estimated to cost, because batching collapsed its
+ * ledger reads and `depthSafety` was deferred so it never simulates a swap.
+ *
+ * The estimate being off by ~4x is the same lesson as the concurrency incident,
+ * pointing the other way: a request count is machine-independent and a duration
+ * is not, so neither one is a substitute for the deployed reading.
+ *
+ * At concurrency 1 this ordering cannot change a cycle's makespan — the sum is
+ * the sum. It is kept correct because it decides the makespan the moment
+ * concurrency rises, and because a list whose comment cites numbers that no
+ * longer hold is a list nobody can check.
  *
  * It lives here rather than beside `buildTargets` for one blunt reason: index.ts
  * is a CommonJS CLI entry point and cannot be imported by a test, so an ordering
  * decision made there is an ordering decision nothing can check.
  */
-const SLOWEST_FIRST: readonly string[] = ['kinetic', 'yieldblox', 'blend'];
+const SLOWEST_FIRST: readonly string[] = [
+  'kinetic',
+  'yieldblox',
+  'etherfuse',
+  'blend',
+  'aquarius-xlm-usdc',
+];
 
 /**
  * Order targets slowest-first. Pure, and total on ids it has never heard of.
@@ -337,6 +353,172 @@ export function orderByLatency(targets: IndexTarget[]): IndexTarget[] {
   // Array.prototype.sort is stable, so equally-ranked targets keep registration
   // order — two unmeasured pools stay in BLEND_POOLS order.
   return [...targets].sort((a, b) => rank(a.metadata.id) - rank(b.metadata.id));
+}
+
+// ---------------------------------------------------------------------------
+// Sharding — which slice of the registry one invocation scores
+// ---------------------------------------------------------------------------
+
+/**
+ * Which slice of the registry a single invocation is responsible for.
+ *
+ * `{ shard: 0, totalShards: 1 }` is "all of it", and is what every caller that
+ * says nothing gets — so the unsharded cron job that exists today keeps working
+ * with no change to it at all.
+ */
+export interface ShardSpec {
+  /** 0-based index of this shard. Always `< totalShards`. */
+  shard: number;
+  /** How many shards the registry is split across. 1 disables sharding. */
+  totalShards: number;
+}
+
+/** The whole registry in one invocation — the default, and the old behaviour. */
+export const SINGLE_SHARD: ShardSpec = { shard: 0, totalShards: 1 };
+
+/**
+ * FNV-1a, 32-bit, over a target id.
+ *
+ * A hash rather than a position because the deal order below must not depend on
+ * the order targets happen to be registered or sorted in — see `selectShard`.
+ * FNV-1a specifically because it is four lines, has no dependency, and is
+ * identical in every runtime: the split has to come out the same in a test, in
+ * `next dev`, and in a minified serverless bundle, and anything reaching for a
+ * runtime identifier or a platform hash would not.
+ *
+ * `Math.imul` and `>>> 0` keep this in 32-bit unsigned arithmetic; without them
+ * the multiply overflows into a float and the result stops being a hash.
+ *
+ * NOT a security primitive and never used as one. The only property required is
+ * that it is a fixed, well-mixed function of the string.
+ */
+export function targetHash(id: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * Split the registry and return the targets belonging to `spec.shard`.
+ *
+ * THE RULE: sort every target by `(targetHash(id), id)` — a total order that is
+ * a function of the ids alone — then deal that order round-robin across the
+ * shards. Position `i` in the deal goes to shard `i % totalShards`.
+ *
+ * BALANCED BY CONSTRUCTION, WHICH IS THE POINT. Shard sizes differ by at most
+ * one, always, so N shards buy exactly N times the registry ceiling. The
+ * obvious alternative — `targetHash(id) % totalShards` — is what makes a
+ * target's shard depend on nothing but itself, and it was measured against this
+ * registry before being rejected: today's five slugs hash to **4 and 1** across
+ * two shards, so the second invocation would buy four slots instead of five,
+ * and at ten targets a two-way split is more likely than not to put six in one
+ * shard and be infeasible outright. Sharding exists to buy capacity; an
+ * assignment that throws a third of it away does not do the job.
+ *
+ * WHAT THAT COSTS, STATED PLAINLY: registering a sixth target can move an
+ * existing target to a different shard. That is safe HERE, and the reason is
+ * worth being explicit about rather than assumed — **nothing in this system is
+ * keyed by shard.** A run record is keyed by protocol; a streak is derived by
+ * `decideAlert` from that protocol's own `risk_scores` rows (see alerts.ts,
+ * "WHY DERIVE"); staleness is per protocol. A target that changes shard is
+ * scored a few minutes earlier or later within the same cadence and nothing
+ * else observes the move. The membership tests in cycle.test.ts pin exactly
+ * that: one target produces the same run record and the same alert decision
+ * from either shard, and from no shard at all. If some future state ever IS
+ * keyed by shard, this is the decision to revisit — not the test to relax.
+ *
+ * INDEPENDENT OF THE INPUT ORDER, deliberately. The deal is sorted by hash, so
+ * `selectShard(orderByLatency(t), s)` and `orderByLatency(selectShard(t, s))`
+ * choose the same members. Ordering and sharding are orthogonal, and neither
+ * has to know the other ran. The RESULT preserves the input order, so a
+ * latency-ordered list stays latency-ordered after the split.
+ *
+ * EXACTLY-ONCE COVERAGE is the load-bearing property: every target lands in
+ * exactly one shard, so running shards `0..totalShards-1` scores the registry
+ * once and once only. `resolveShardSpec` is what refuses a spec that would
+ * break it.
+ */
+export function selectShard(targets: IndexTarget[], spec: ShardSpec): IndexTarget[] {
+  const { shard, totalShards } = spec;
+  if (totalShards <= 1) return [...targets];
+
+  // Sorted by hash, with the id as the tie-break so two ids that collide still
+  // have one fixed order rather than whichever the input happened to carry.
+  const deal = [...targets].sort((a, b) => {
+    const ha = targetHash(a.metadata.id);
+    const hb = targetHash(b.metadata.id);
+    return ha === hb ? a.metadata.id.localeCompare(b.metadata.id) : ha - hb;
+  });
+
+  const mine = new Set<string>();
+  deal.forEach((target, i) => {
+    if (i % totalShards === shard) mine.add(target.metadata.id);
+  });
+
+  // Filtered from the ORIGINAL list, not from `deal`, so whatever order the
+  // caller established survives the split.
+  return targets.filter((t) => mine.has(t.metadata.id));
+}
+
+/** A validated spec, or the reason it was refused. */
+export type ShardSpecResult = { ok: true; spec: ShardSpec } | { ok: false; error: string };
+
+/**
+ * Turn two optional raw parameters into a spec, refusing anything that would
+ * break exactly-once coverage.
+ *
+ * It takes strings because the only caller that passes anything is the cron
+ * route's query string, and it lives here rather than there for the same blunt
+ * reason `orderByLatency` does: a route handler is not a thing this repo can
+ * load from a test, so a coverage rule enforced in one is a coverage rule
+ * nothing checks. The rule, not the transport, is the load-bearing part.
+ *
+ * BOTH OR NEITHER. `?shard=1` with no `totalShards` is not "shard 1 of the
+ * default" — it is a half-configured cron job, and the honest response to it is
+ * a 400 rather than a cycle that silently scores the wrong subset. The
+ * both-absent case is the unsharded default, which is what keeps the existing
+ * job working untouched.
+ */
+export function resolveShardSpec(
+  rawShard: string | null | undefined,
+  rawTotalShards: string | null | undefined,
+): ShardSpecResult {
+  const shardText = rawShard?.trim() ?? '';
+  const totalText = rawTotalShards?.trim() ?? '';
+
+  if (shardText === '' && totalText === '') return { ok: true, spec: SINGLE_SHARD };
+  if (shardText === '' || totalText === '') {
+    return { ok: false, error: 'shard and totalShards must be given together, or both omitted' };
+  }
+
+  // A plain-integer test rather than Number(), which would accept '1e0', '0x1'
+  // and ' 1 ' — a cron job's URL should carry an integer or be told it doesn't.
+  const isInt = (t: string): boolean => /^[0-9]+$/.test(t);
+  if (!isInt(shardText) || !isInt(totalText)) {
+    return {
+      ok: false,
+      error: `shard and totalShards must be non-negative integers, got "${shardText}" and "${totalText}"`,
+    };
+  }
+
+  const shard = Number(shardText);
+  const totalShards = Number(totalText);
+  if (totalShards < 1) {
+    return { ok: false, error: `totalShards must be at least 1, got ${totalShards}` };
+  }
+  if (shard >= totalShards) {
+    // The spec that silently scores nothing. Refused loudly, because a job
+    // configured `shard=2&totalShards=2` would otherwise return a cheerful
+    // `ran: 0` forever while a third of the registry quietly went stale.
+    return {
+      ok: false,
+      error: `shard must be less than totalShards, got shard=${shard} of ${totalShards}`,
+    };
+  }
+  return { ok: true, spec: { shard, totalShards } };
 }
 
 /**

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -30,13 +30,16 @@ import { closePool, createStore, getPool, type Store } from '@stenion/db';
 import { webhookNotifier } from './alerts';
 import { ConfigError, loadConfig, type IndexerConfig } from './config';
 import {
+  SINGLE_SHARD,
   cycleFeasibility,
   feasibilityWarning,
   orderByLatency,
   runCycle,
+  selectShard,
   toTarget,
   type CycleOptions,
   type IndexTarget,
+  type ShardSpec,
 } from './cycle';
 
 // The run loop itself lives in ./cycle so it can be tested without this file's
@@ -44,11 +47,15 @@ import {
 // because @stenion/indexer's entry point is this module — the package's public
 // surface is unchanged.
 export {
+  SINGLE_SHARD,
   cycleFeasibility,
   feasibilityWarning,
   orderByLatency,
+  resolveShardSpec,
   runCycle,
+  selectShard,
   targetDeadline,
+  targetHash,
   toTarget,
 } from './cycle';
 export type {
@@ -57,6 +64,8 @@ export type {
   CycleRunResult,
   CycleSummary,
   IndexTarget,
+  ShardSpec,
+  ShardSpecResult,
 } from './cycle';
 export type { StreakAlert } from './alerts';
 import type { CycleSummary } from './cycle';
@@ -111,12 +120,27 @@ function buildTargets(config: IndexerConfig): IndexTarget[] {
 }
 
 /**
- * Build the targets, connect, and upsert protocol metadata (idempotent). Shared
- * by the standalone loop (main) and the single-cycle entry point (runIndexerCycle).
- * Throws on a bad DATABASE_URL / unreachable DB — callers decide how to report it.
+ * Build the targets, narrow them to this invocation's shard, connect, and upsert
+ * protocol metadata (idempotent). Shared by the standalone loop (main) and the
+ * single-cycle entry point (runIndexerCycle). Throws on a bad DATABASE_URL /
+ * unreachable DB — callers decide how to report it.
+ *
+ * THE SHARD IS APPLIED AFTER `orderByLatency`, and it has to be: `selectShard`
+ * preserves the order of the list it is given, so the subset this invocation
+ * runs is still slowest-first. It chooses its members from the ids alone, so the
+ * two compose in either order — see `selectShard`.
+ *
+ * The upsert loop covers this shard's protocols only. Every target belongs to
+ * exactly one shard, so the registry is still upserted in full across a full
+ * rotation; a protocol whose shard's cron job is broken stops being refreshed
+ * AND stops being scored, which is the same fact and is what `/api/v1/health`
+ * reports as staleness.
  */
-async function prepare(config: IndexerConfig): Promise<{ targets: IndexTarget[]; store: Store }> {
-  const targets = buildTargets(config);
+async function prepare(
+  config: IndexerConfig,
+  spec: ShardSpec,
+): Promise<{ targets: IndexTarget[]; store: Store }> {
+  const targets = selectShard(buildTargets(config), spec);
   const store = createStore(getPool());
   // Protocol metadata is static, so upsert once here; the run loop only appends
   // scores.
@@ -150,17 +174,21 @@ function cycleOptions(config: IndexerConfig): CycleOptions {
 }
 
 /**
- * Run exactly one scoring cycle and return a summary. This is the entry point the
- * dashboard's cron route (app/api/cron/run-indexer) calls: external scheduling
- * (a cron-job.org job, every 5 min) triggers the route, the route calls this, one
- * cycle writes to Postgres. Deliberately does NOT close the pool — under
- * serverless the pg Pool is reused across warm invocations; the Neon pooler owns
- * connection lifecycle. Config comes from validated env (loadConfig); a bad env
- * or unreachable DB throws (the route turns that into a 500).
+ * Run exactly one scoring cycle over one shard of the registry, and return a
+ * summary. This is the entry point the dashboard's cron route
+ * (app/api/cron/run-indexer) calls: external scheduling (cron-job.org jobs, one
+ * per shard, every 5 min) triggers the route, the route calls this, one cycle
+ * writes to Postgres. Deliberately does NOT close the pool — under serverless the
+ * pg Pool is reused across warm invocations; the Neon pooler owns connection
+ * lifecycle. Config comes from validated env (loadConfig); a bad env or
+ * unreachable DB throws (the route turns that into a 500).
+ *
+ * `spec` defaults to the whole registry, so a caller that says nothing gets
+ * exactly the cycle that ran before sharding existed.
  */
-export async function runIndexerCycle(): Promise<CycleSummary> {
+export async function runIndexerCycle(spec: ShardSpec = SINGLE_SHARD): Promise<CycleSummary> {
   const config = loadConfig();
-  const { targets, store } = await prepare(config);
+  const { targets, store } = await prepare(config, spec);
   return runCycle(targets, store, cycleOptions(config));
 }
 
@@ -182,9 +210,13 @@ async function main(): Promise<void> {
 
   // A failure here (bad DATABASE_URL, unreachable DB) should stop us before the
   // first cycle rather than silently drop every write.
+  // The standalone loop runs the WHOLE registry. Sharding exists to fit the
+  // serverless `maxDuration` ceiling, and a long-lived process has no such
+  // ceiling — splitting it here would buy nothing and cost a second thing to
+  // configure. `runIndexerCycle` is the entry point that takes a shard.
   let prepared: { targets: IndexTarget[]; store: Store };
   try {
-    prepared = await prepare(config);
+    prepared = await prepare(config, SINGLE_SHARD);
   } catch (err) {
     console.error(
       `Cannot reach the database — check DATABASE_URL and that migrations have run ` +


### PR DESCRIPTION
Shard indexer targets across multiple cron invocations to break Vercel's 60s ceiling
