### PR TITLE
feat: add registry export controls

### DIFF
--- a/dashboard/app/lib/registry-query.test.ts
+++ b/dashboard/app/lib/registry-query.test.ts
@@ -9,6 +9,8 @@ import {
   groupRankedByCategory,
   matchesQuery,
   parseRegistryParams,
+  registryExportHref,
+  registryExportLinks,
   partitionScored,
   registryHref,
   sortRanked,
@@ -270,6 +272,48 @@ describe('registryHref', () => {
     );
     assert.equal(parsed.category, 'all');
     assert.equal(registryHref(parsed), '/registry');
+  });
+});
+
+describe('registryExportLinks', () => {
+  it('targets the current-state export endpoint for CSV and JSON', () => {
+    assert.equal(registryExportHref('csv'), '/api/v1/protocols/export?format=csv');
+    assert.equal(registryExportHref('json'), '/api/v1/protocols/export?format=json');
+    assert.deepEqual(
+      registryExportLinks().map((link) => [link.label, link.href]),
+      [
+        ['CSV', '/api/v1/protocols/export?format=csv'],
+        ['JSON', '/api/v1/protocols/export?format=json'],
+      ],
+    );
+  });
+
+  it('does not encode the filtered or sorted registry view into export URLs', () => {
+    const filtered = registryHref({
+      q: 'blend',
+      status: 'scored',
+      category: 'lending',
+      sort: 'score-asc',
+    });
+    assert.equal(filtered, '/registry?q=blend&status=scored&category=lending&sort=score-asc');
+
+    for (const link of registryExportLinks()) {
+      const url = new URL(link.href, 'https://stenion.test');
+      assert.equal(url.pathname, '/api/v1/protocols/export');
+      assert.equal(url.searchParams.get('format'), link.format);
+      assert.equal(url.searchParams.has('q'), false);
+      assert.equal(url.searchParams.has('status'), false);
+      assert.equal(url.searchParams.has('category'), false);
+      assert.equal(url.searchParams.has('sort'), false);
+    }
+  });
+
+  it('provides ordinary labelled links, so keyboard access stays native', () => {
+    for (const link of registryExportLinks()) {
+      assert.match(link.ariaLabel, /^Download current registry snapshot as (CSV|JSON)$/);
+      assert.ok(link.href.startsWith('/api/v1/protocols/export?format='));
+      assert.equal(link.label.length > 0, true);
+    }
   });
 });
 

--- a/dashboard/app/lib/registry-query.ts
+++ b/dashboard/app/lib/registry-query.ts
@@ -89,6 +89,16 @@ export type RegistryCategoryFilter = 'all' | ProtocolCategory;
 
 export const DEFAULT_CATEGORY: RegistryCategoryFilter = 'all';
 
+export const REGISTRY_EXPORT_FORMATS = ['csv', 'json'] as const;
+export type RegistryExportFormat = (typeof REGISTRY_EXPORT_FORMATS)[number];
+
+export interface RegistryExportLink {
+  format: RegistryExportFormat;
+  label: string;
+  href: string;
+  ariaLabel: string;
+}
+
 /**
  * How a category is written where a reader sees it — a section heading above a
  * ranked block, or an option in the filter.
@@ -180,6 +190,27 @@ export function registryHref(params: Partial<RegistryParams>): string {
   if (params.sort && params.sort !== DEFAULT_SORT) search.set('sort', params.sort);
   const qs = search.toString();
   return qs ? `/registry?${qs}` : '/registry';
+}
+
+export function registryExportHref(format: RegistryExportFormat): string {
+  return `/api/v1/protocols/export?format=${format}`;
+}
+
+export function registryExportLinks(): RegistryExportLink[] {
+  return [
+    {
+      format: 'csv',
+      label: 'CSV',
+      href: registryExportHref('csv'),
+      ariaLabel: 'Download current registry snapshot as CSV',
+    },
+    {
+      format: 'json',
+      label: 'JSON',
+      href: registryExportHref('json'),
+      ariaLabel: 'Download current registry snapshot as JSON',
+    },
+  ];
 }
 
 /**

--- a/dashboard/components/registry-controls.tsx
+++ b/dashboard/components/registry-controls.tsx
@@ -22,11 +22,12 @@
 
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import { Loader2, Search, X } from 'lucide-react';
+import { Download, Loader2, Search, X } from 'lucide-react';
 
 import { cn } from '../app/lib/cn';
 import {
   REGISTRY_SORTS,
+  registryExportLinks,
   registryHref,
   type RegistryCategoryFilter,
   type RegistryParams,
@@ -120,6 +121,7 @@ export function RegistryControls({
       router.replace(registryHref({ ...params, q, ...next }), { scroll: false });
     });
   };
+  const exportLinks = registryExportLinks();
 
   return (
     <form
@@ -131,10 +133,10 @@ export function RegistryControls({
         e.preventDefault();
         go({ q });
       }}
-      className={cn('flex flex-col gap-3 sm:flex-row sm:items-center', className)}
+      className={cn('flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center', className)}
       role="search"
     >
-      <div className="relative flex-1">
+      <div className="relative flex-1 sm:min-w-64">
         {/* One slot, two icons: the magnifier idle, a spinner in flight. Same
             position and size, so nothing shifts as it swaps. */}
         {isPending ? (
@@ -180,7 +182,7 @@ export function RegistryControls({
         )}
       </div>
 
-      <div className="flex gap-3">
+      <div className="flex flex-wrap gap-3">
         <Select
           id="registry-status"
           name="status"
@@ -234,6 +236,25 @@ export function RegistryControls({
             </option>
           ))}
         </Select>
+      </div>
+
+      <div
+        className="flex items-center gap-1.5 rounded-lg border border-line bg-surface px-2 py-1.5"
+        role="group"
+        aria-label="Export current registry snapshot"
+      >
+        <Download className="h-4 w-4 text-faint" aria-hidden="true" />
+        <span className="text-sm text-muted">Export</span>
+        {exportLinks.map((link) => (
+          <a
+            key={link.format}
+            href={link.href}
+            aria-label={link.ariaLabel}
+            className="rounded px-2 py-1 text-sm font-medium text-accent-ink transition-colors hover:bg-accent/10 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            {link.label}
+          </a>
+        ))}
       </div>
 
       {/* The no-JS submit. Hidden from pointer users once the enhancement is


### PR DESCRIPTION
## What this changes

Adds CSV and JSON export controls to the registry page for the current-state export introduced in #139.

The controls use native links to the existing export endpoint because it already returns `Content-Disposition: attachment` with deterministic filenames. Registry search/filter/sort state is intentionally not included in export URLs.

Closes #140.

## Verification

- `pnpm format:check`
- `pnpm lint` — passes with the existing unrelated `scripts/capture-fixture.mjs` unused-`URL` warning
- `pnpm typecheck`
- focused registry/export tests — 60 passed
- `pnpm test`
- `pnpm build`
- `pnpm build:dashboard`
- `git diff --check`

Independent QA also validated the exact candidate against an ephemeral PostgreSQL 16 database with all migrations applied:

- CSV download: HTTP 200
  - `Content-Type: text/csv; charset=utf-8`
  - `Content-Disposition: attachment; filename="stenion-registry-current.csv"`
- JSON download: HTTP 200
  - `Content-Type: application/json; charset=utf-8`
  - `Content-Disposition: attachment; filename="stenion-registry-current.json"`
- omitted format defaults to JSON
- unsupported format returns HTTP 400
- filtered registry query parameters do not alter export output
- native CSV/JSON anchors remain independent of registry filter/search/sort state
- desktop and narrow/mobile registry layouts were visually checked
- anti-vacuity mutation proved the new export-link assertions fail when the format mapping is wrong

## Checklist

- [x] **Base branch is `dev`**, not `main`.
- [x] `pnpm build`, `pnpm lint`, `pnpm typecheck`, and repository validation pass.
- [x] On-chain method/field confirmation: N/A — no adapter or on-chain changes.
- [x] `*Safety` factors: N/A — no scoring changes.
- [x] No fabricated numbers — no scoring/data computation changes.
- [x] `methodology/` update: N/A — no methodology change.
- [x] No new dependencies.
