### PR TITLE
fix: resolve capture fixture lint warning

### DIFF
--- a/scripts/capture-fixture.mjs
+++ b/scripts/capture-fixture.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* global console, process, URL */
+/* global console, process */
 //
 // Capture a live mainnet snapshot of an adapter's raw on-chain state, for use as
 // a frozen regression fixture (adapters/fixtures/**/*.ts).


### PR DESCRIPTION
## Summary

- remove the stale `URL` declaration from the file-level ESLint globals in `scripts/capture-fixture.mjs`
- preserve the script's runtime behaviour
- make the workspace lint run fully clean

## Validation

- `pnpm lint` — PASS, 0 warnings / 0 errors
- `pnpm format:check` — PASS
- `pnpm typecheck` — PASS
- `pnpm test` — PASS
- `node --check scripts/capture-fixture.mjs` — PASS
- `git diff --check` — PASS

Closes #119